### PR TITLE
fix(cli): report generation failures with a nonzero exit code

### DIFF
--- a/cmd/zas/main.go
+++ b/cmd/zas/main.go
@@ -37,16 +37,17 @@ var subcommands = []*zas.Subcommand{
 
 var (
 	verbose, full *bool
-	cmdInit = zas.NewSubcommand("init", func() {
+	cmdInit = zas.NewSubcommand("init", func() error {
 		i := zas.Init{}
 		i.Run()
+		return nil
 	})
-	cmdGenerate = zas.NewSubcommand("generate", func() {
+	cmdGenerate = zas.NewSubcommand("generate", func() error {
 		g := zas.Generator{
 			Verbose: *verbose,
 			Full:    *full,
 		}
-		g.Run()
+		return g.Run()
 	})
 )
 
@@ -74,7 +75,11 @@ func main() {
 	for _, cmd := range subcommands {
 		if cmd.Name == command && cmd.Run != nil {
 			cmd.Flag.Parse(args[1:])
-			cmd.Run()
+
+			if err := cmd.Run(); err != nil {
+				fmt.Fprintf(os.Stderr, "fatal: %s\n", err)
+				os.Exit(1)
+			}
 
 			os.Exit(0)
 		}

--- a/generate.go
+++ b/generate.go
@@ -19,6 +19,7 @@ package zas
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"html"
 	thtml "html/template"
@@ -64,6 +65,10 @@ type Generator struct {
 	cachedZasDirectoryConfigs map[string]ConfigSection
 
 	wg sync.WaitGroup
+
+	// Guards errs, which collects per-file render errors from renderAsync goroutines.
+	mu   sync.Mutex
+	errs []error
 }
 
 /*
@@ -118,8 +123,7 @@ func (gen *Generator) Run() error {
 	cfg, err := NewConfig()
 	if err != nil {
 		if os.IsNotExist(err) {
-			fmt.Printf("fatal: Not a valid Zas repository: %s\n", err)
-			return err
+			return fmt.Errorf("not a valid Zas repository: %w", err)
 		}
 		return err
 	}
@@ -146,6 +150,9 @@ func (gen *Generator) Run() error {
 		if err = filepath.Walk(gen.GetDeployPath(), reapwalk); err != nil {
 			return err
 		}
+	}
+	if len(gen.errs) > 0 {
+		return errors.Join(gen.errs...)
 	}
 	return nil
 }
@@ -224,7 +231,9 @@ func (gen *Generator) renderAsync(path string) {
 	}
 
 	if err != nil {
-		fmt.Printf("fatal: %s => %s\n", path, err)
+		gen.mu.Lock()
+		gen.errs = append(gen.errs, fmt.Errorf("%s: %w", path, err))
+		gen.mu.Unlock()
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/darccio/zas
 
-go 1.20
+go 1.26
 
 require (
 	dario.cat/mergo v1.0.0

--- a/subcommand.go
+++ b/subcommand.go
@@ -13,7 +13,7 @@ import (
 type Subcommand struct {
 	// Runs the subcommand
 	// The args are the arguments after the subcommand name.
-	Run func()
+	Run func() error
 
 	// UsageLine is the one-line usage message.
 	// The first word in the line is taken to be the subcommand name.
@@ -26,7 +26,7 @@ type Subcommand struct {
 	Flag flag.FlagSet
 }
 
-func NewSubcommand(usageLine string, run func()) *Subcommand {
+func NewSubcommand(usageLine string, run func() error) *Subcommand {
 	data := strings.SplitN(usageLine, " ", 2)
 	return &Subcommand{
 		UsageLine: usageLine,


### PR DESCRIPTION
## Summary
- Addresses that `zas` always exited 0 after `generate`, even on outright failure (no `.zas` repo) or partial failure (some pages fail to render).
- `Subcommand.Run` now returns an `error`; `main()` prints it to stderr and exits 1 on failure instead of unconditionally exiting 0.
- `Generator` collects per-file render errors (previously printed to stdout from inside a goroutine and dropped) and returns them joined from `Run()`, so a partial build is no longer reported as a clean one.
- The "not a valid Zas repository" message moves off stdout to stderr, printed once by `main()`.
- Bumped `go.mod` to Go 1.26 (separate commit); this is a CLI with no downstream module consumers, so no compatibility cost.

## Test plan
- [x] `go build ./...` and `go vet ./...`
- [x] Empty directory (no `.zas`): `zas; echo $?` → fatal message on stderr, exit code 1, nothing on stdout
- [x] Site fixture with one valid page and one page with an invalid Go template: `zas generate; echo $?` → fatal error on stderr, exit code 1, valid page still generated (partial-but-reported build)
- [x] Site fixture with only valid pages: `zas generate; echo $?` → exit code 0, no fatal output (no regression on the happy path)