### PR TITLE
fix: eliminate data races and panic-on-input crashes in generation

### DIFF
--- a/cmd/zas/main.go
+++ b/cmd/zas/main.go
@@ -39,8 +39,7 @@ var (
 	verbose, full *bool
 	cmdInit = zas.NewSubcommand("init", func() error {
 		i := zas.Init{}
-		i.Run()
-		return nil
+		return i.Run()
 	})
 	cmdGenerate = zas.NewSubcommand("generate", func() error {
 		g := zas.Generator{

--- a/configsection_test.go
+++ b/configsection_test.go
@@ -1,0 +1,47 @@
+package zas
+
+import "testing"
+
+// B2: ConfigSection.GetString/GetSection must return zero values instead of
+// panicking on a missing or wrongly-typed key.
+
+func TestGetStringMissingKey(t *testing.T) {
+	cs := ConfigSection{}
+	if got := cs.GetString("nope"); got != "" {
+		t.Fatalf("GetString() = %q, want empty string", got)
+	}
+}
+
+func TestGetStringNonStringValue(t *testing.T) {
+	cs := ConfigSection{"baseurl": 123}
+	if got := cs.GetString("baseurl"); got != "" {
+		t.Fatalf("GetString() = %q, want empty string", got)
+	}
+}
+
+func TestGetSectionMissingKey(t *testing.T) {
+	cs := ConfigSection{}
+	if got := cs.GetSection("nope"); got != nil {
+		t.Fatalf("GetSection() = %v, want nil", got)
+	}
+}
+
+func TestGetSectionScalarValue(t *testing.T) {
+	cs := ConfigSection{"site": "not-a-section"}
+	if got := cs.GetSection("site"); got != nil {
+		t.Fatalf("GetSection() = %v, want nil", got)
+	}
+}
+
+func TestGetSectionRawYAMLMap(t *testing.T) {
+	// yaml.Unmarshal produces nested sections as map[interface{}]interface{},
+	// not ConfigSection - GetSection must still recognize them.
+	cs := ConfigSection{"site": map[interface{}]interface{}{"language": "en"}}
+	section := cs.GetSection("site")
+	if section == nil {
+		t.Fatal("GetSection() = nil, want a section")
+	}
+	if got := section.GetString("language"); got != "en" {
+		t.Fatalf("GetString() = %q, want %q", got, "en")
+	}
+}

--- a/data.go
+++ b/data.go
@@ -100,11 +100,18 @@ func (zd *ZasData) Extra(keypath string) (value string, err error) {
 	return
 }
 
-func (zd *ZasData) Language() (language string) {
+func (zd *ZasData) Language() (string, error) {
 	return zd.Resolve("language")
 }
 
-func (zd *ZasData) Resolve(id string) string {
+/*
+ * Resolves id from Page, then Directory, then site-wide Extra config, in
+ * that order. Returns an error only when id is present in Page or Directory
+ * but isn't a string (e.g. a page-config typo like "language:" with no
+ * value, or a numeric value) — a genuinely absent key still falls back to
+ * Extra's own lenient "" default.
+ */
+func (zd *ZasData) Resolve(id string) (string, error) {
 	var (
 		value interface{}
 		ok    bool
@@ -115,15 +122,23 @@ func (zd *ZasData) Resolve(id string) string {
 			value, ok = zd.Directory[id]
 		}
 		if !ok {
-			value, _ = zd.Extra(fmt.Sprintf("/site/%s", id))
+			s, _ := zd.Extra(fmt.Sprintf("/site/%s", id))
+			return s, nil
 		}
 	}
-	return value.(string)
+	s, isString := value.(string)
+	if !isString {
+		return "", fmt.Errorf("config value %q must be a string, got %T", id, value)
+	}
+	return s, nil
 }
 
-func (zd *ZasData) E(s string, a ...interface{}) (t string) {
-	var err error
-	zd.i18n.SetTarget(zd.Language())
+func (zd *ZasData) E(s string, a ...interface{}) (t string, err error) {
+	lang, err := zd.Language()
+	if err != nil {
+		return "", err
+	}
+	zd.i18n.SetTarget(lang)
 	if len(a) == 0 {
 		t, err = zd.i18n.Translate(s)
 	} else {
@@ -136,12 +151,17 @@ func (zd *ZasData) E(s string, a ...interface{}) (t string) {
 	return
 }
 
-func (zd *ZasData) H(s string, a ...interface{}) (h thtml.HTML) {
-	return thtml.HTML(zd.E(s, a...))
+func (zd *ZasData) H(s string, a ...interface{}) (h thtml.HTML, err error) {
+	t, err := zd.E(s, a...)
+	return thtml.HTML(t), err
 }
 
-func (zd *ZasData) IsHome() bool {
-	return zd.Path == "/index.html" || zd.Path == fmt.Sprintf("/%s/index.html", zd.Language())
+func (zd *ZasData) IsHome() (bool, error) {
+	lang, err := zd.Language()
+	if err != nil {
+		return false, err
+	}
+	return zd.Path == "/index.html" || zd.Path == fmt.Sprintf("/%s/index.html", lang), nil
 }
 
 func NewZasData(filepath string, gen *Generator) (data ZasData) {

--- a/data.go
+++ b/data.go
@@ -151,7 +151,13 @@ func NewZasData(filepath string, gen *Generator) (data ZasData) {
 	}
 	data.Path = fmt.Sprintf("/%s", filepath)
 	data.config = gen.Config
-	data.i18n = gen.I18n
+	// Each ZasData gets its own gt.Build sharing the (read-only, post-init)
+	// Index, so per-render SetTarget/Translate calls don't race or bleed
+	// across languages on a Build shared by every render goroutine.
+	data.i18n = &gt.Build{
+		Index:  gen.I18n.Index,
+		Origin: gen.I18n.Origin,
+	}
 	data.Site.BaseURL = gen.Config.GetSection("site").GetString("baseurl")
 	data.Site.Image = gen.Config.GetSection("site").GetString("image")
 	return

--- a/dirconfig_race_test.go
+++ b/dirconfig_race_test.go
@@ -1,0 +1,57 @@
+package zas
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+)
+
+// C1: cachedZasDirectoryConfigs is read and written by every renderAsync
+// goroutine; run this under `go test -race` to prove there's no longer a
+// concurrent map read/write.
+func TestLoadZasDirectoryConfigConcurrent(t *testing.T) {
+	t.Chdir(t.TempDir())
+	must := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	must(os.MkdirAll("a/sub", 0o755))
+	must(os.MkdirAll("b", 0o755))
+	must(os.WriteFile("a/"+ZAS_DIR_CONF_FILE, []byte("lang: a\n"), 0o644))
+	must(os.WriteFile("b/"+ZAS_DIR_CONF_FILE, []byte("lang: b\n"), 0o644))
+
+	gen := &Generator{}
+	// a/sub has no .zas.yml of its own, so it must recurse up to a/'s config.
+	cases := map[string]string{
+		"a/page1.html":     "a",
+		"a/sub/page2.html": "a",
+		"b/page3.html":     "b",
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(cases)*50)
+	for path, wantLang := range cases {
+		for range 50 {
+			wg.Add(1)
+			go func(path, wantLang string) {
+				defer wg.Done()
+				cfg, err := gen.loadZasDirectoryConfig(path)
+				if err != nil {
+					errCh <- fmt.Errorf("%s: %w", path, err)
+					return
+				}
+				if got := cfg.GetString("lang"); got != wantLang {
+					errCh <- fmt.Errorf("%s: lang = %q, want %q", path, got, wantLang)
+				}
+			}(path, wantLang)
+		}
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Error(err)
+	}
+}

--- a/embed_dispatch_test.go
+++ b/embed_dispatch_test.go
@@ -1,0 +1,48 @@
+package zas
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+// B6: config data must not be able to pick an arbitrary Generator method via
+// reflection and panic method.Call with a mismatched arity/signature.
+
+func TestIsEmbedPluginMethod(t *testing.T) {
+	gen := &Generator{}
+
+	if valid := reflect.ValueOf(gen).MethodByName("Markdown"); !isEmbedPluginMethod(valid) {
+		t.Fatal("isEmbedPluginMethod(Markdown) = false, want true")
+	}
+	// Run() error is a real exported Generator method, but with the wrong
+	// arity (0 args) for embed dispatch - must be rejected, not panic.
+	if wrongArity := reflect.ValueOf(gen).MethodByName("Run"); isEmbedPluginMethod(wrongArity) {
+		t.Fatal("isEmbedPluginMethod(Run) = true, want false")
+	}
+	if notFound := reflect.ValueOf(gen).MethodByName("DoesNotExist"); isEmbedPluginMethod(notFound) {
+		t.Fatal("isEmbedPluginMethod(missing method) = true, want false")
+	}
+}
+
+func TestHandleEmbedTagsFallsBackOnWrongArityMethod(t *testing.T) {
+	// Reproduces the audit repro: mimetypes: {text/x-t: run} resolves to the
+	// real, exported Run() error method, which has the wrong signature for
+	// embed dispatch. Must fall back to the external plugin path instead of
+	// panicking in reflect.Value.Call. The fallback path itself is a no-op
+	// here (see audit A1, out of scope), so simply completing without a
+	// panic is the regression this guards.
+	gen := &Generator{
+		Config: ConfigSection{
+			"mimetypes": ConfigSection{"text/x-t": "run"},
+		},
+	}
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(
+		`<html><body><embed src="x" type="text/x-t"></body></html>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = gen.handleEmbedTags(doc, &ZasData{})
+}

--- a/generate.go
+++ b/generate.go
@@ -63,6 +63,8 @@ type Generator struct {
 	I18n *gt.Build
 	// ZasDirectoryConfigs cache
 	cachedZasDirectoryConfigs map[string]ConfigSection
+	// Guards cachedZasDirectoryConfigs, read and written from many renderAsync goroutines.
+	dirConfigMu sync.Mutex
 
 	wg sync.WaitGroup
 
@@ -332,27 +334,46 @@ func (gen *Generator) renderHTML(path string) (err error) {
  * It must be a YAML file.
  */
 func (gen *Generator) loadZasDirectoryConfig(currentpath string) (config ConfigSection, err error) {
-	var ok bool
 	path := filepath.Dir(currentpath)
-	if config, ok = gen.cachedZasDirectoryConfigs[path]; !ok {
-		data, err := os.ReadFile(fmt.Sprintf("%s/%s", path, ZAS_DIR_CONF_FILE))
-		if err != nil {
-			// Maybe .zas.yml is in an upper directory (already cached or not),
-			// so we call this recursively.
-			// Unless we are at current working directory.
-			if path == "." {
-				return nil, err
-			}
-			return gen.loadZasDirectoryConfig(path)
-		}
-		config = make(ConfigSection)
-		_ = yaml.Unmarshal(data, &config)
-		if gen.cachedZasDirectoryConfigs == nil {
-			gen.cachedZasDirectoryConfigs = make(map[string]ConfigSection)
-		}
-		gen.cachedZasDirectoryConfigs[path] = config
+	if config, ok := gen.getCachedDirConfig(path); ok {
+		return config, nil
 	}
+	data, err := os.ReadFile(fmt.Sprintf("%s/%s", path, ZAS_DIR_CONF_FILE))
+	if err != nil {
+		// Maybe .zas.yml is in an upper directory (already cached or not),
+		// so we call this recursively.
+		// Unless we are at current working directory.
+		if path == "." {
+			return nil, err
+		}
+		return gen.loadZasDirectoryConfig(path)
+	}
+	config = make(ConfigSection)
+	_ = yaml.Unmarshal(data, &config)
+	gen.setCachedDirConfig(path, config)
+	return config, nil
+}
+
+/*
+ * Reads cachedZasDirectoryConfigs, safe for concurrent use.
+ */
+func (gen *Generator) getCachedDirConfig(path string) (config ConfigSection, ok bool) {
+	gen.dirConfigMu.Lock()
+	defer gen.dirConfigMu.Unlock()
+	config, ok = gen.cachedZasDirectoryConfigs[path]
 	return
+}
+
+/*
+ * Writes cachedZasDirectoryConfigs, safe for concurrent use.
+ */
+func (gen *Generator) setCachedDirConfig(path string, config ConfigSection) {
+	gen.dirConfigMu.Lock()
+	defer gen.dirConfigMu.Unlock()
+	if gen.cachedZasDirectoryConfigs == nil {
+		gen.cachedZasDirectoryConfigs = make(map[string]ConfigSection)
+	}
+	gen.cachedZasDirectoryConfigs[path] = config
 }
 
 /*

--- a/generate.go
+++ b/generate.go
@@ -216,6 +216,9 @@ func (gen *Generator) handleDeployPath(full bool) {
  * Real walking function. Handles all supported files and copy not supported ones in current deployment path.
  */
 func (gen *Generator) walk(path string, info os.FileInfo, err error) (ierr error) {
+	if err != nil {
+		return err
+	}
 	if strings.HasPrefix(path, ".") || strings.HasPrefix(filepath.Base(path), ".") || strings.Contains(path, fmt.Sprintf("%s/", ZAS_DIR)) {
 		return
 	}
@@ -257,6 +260,9 @@ func (gen *Generator) renderAsync(path string) {
  * Real reaping function. Reaps all missing source files in current deployment path.
  */
 func (gen *Generator) reaper(path string, info os.FileInfo, err error) (ierr error) {
+	if err != nil {
+		return err
+	}
 	sourcePath := strings.Replace(path, gen.GetDeployPath(), ".", 1)
 	source, err := os.Open(sourcePath)
 	// TODO it must clean directories too

--- a/generate.go
+++ b/generate.go
@@ -302,7 +302,10 @@ func (gen *Generator) sourceIsNewer(path string, sourceInfo os.FileInfo) bool {
 		return true
 	}
 	defer destination.Close()
-	destinationInfo, _ := destination.Stat()
+	destinationInfo, err := destination.Stat()
+	if err != nil {
+		return true
+	}
 	return sourceInfo.ModTime().UnixNano() >= destinationInfo.ModTime().UnixNano()
 }
 

--- a/generate.go
+++ b/generate.go
@@ -576,7 +576,7 @@ func (gen *Generator) handleEmbedTags(doc *goquery.Document, data *ZasData) (err
 			}
 			plugin := gen.resolveMIMETypePlugin(typ)
 			method := reflect.ValueOf(gen).MethodByName(cases.Title(language.English).String(plugin))
-			if method == reflect.ValueOf(nil) {
+			if !isEmbedPluginMethod(method) {
 				err = gen.handleMIMETypePlugin(e, doc)
 			} else {
 				args := make([]reflect.Value, 3)
@@ -596,6 +596,34 @@ func (gen *Generator) handleEmbedTags(doc *goquery.Document, data *ZasData) (err
 		return true
 	})
 	return
+}
+
+/*
+ * Reports whether method is a valid embed-plugin dispatch target: a method
+ * with the exact (e *goquery.Selection, doc *goquery.Document, data *ZasData) error
+ * signature. Config data chooses the method name (see resolveMIMETypePlugin),
+ * so any exported Generator method is reachable by MethodByName and must be
+ * shape-checked before Call to avoid a reflect panic on arity/type mismatch.
+ */
+func isEmbedPluginMethod(method reflect.Value) bool {
+	if !method.IsValid() {
+		return false
+	}
+	want := []reflect.Type{
+		reflect.TypeFor[*goquery.Selection](),
+		reflect.TypeFor[*goquery.Document](),
+		reflect.TypeFor[*ZasData](),
+	}
+	t := method.Type()
+	if t.NumIn() != len(want) || t.NumOut() != 1 {
+		return false
+	}
+	for i, w := range want {
+		if t.In(i) != w {
+			return false
+		}
+	}
+	return true
 }
 
 type bufErr struct {

--- a/generate.go
+++ b/generate.go
@@ -72,6 +72,15 @@ type Generator struct {
 }
 
 /*
+ * Records err for later aggregation, safe for concurrent use.
+ */
+func (gen *Generator) recordErr(err error) {
+	gen.mu.Lock()
+	gen.errs = append(gen.errs, err)
+	gen.mu.Unlock()
+}
+
+/*
  * Returns deployment base path in config.
  */
 func (gen *Generator) GetDeployPath() string {
@@ -133,6 +142,9 @@ func (gen *Generator) Run() error {
 	go gen.loadI18N()
 	go gen.handleDeployPath(gen.Full)
 	gen.wg.Wait()
+	if len(gen.errs) > 0 {
+		return errors.Join(gen.errs...)
+	}
 	// Walking function. It allows to bubble up any error from generator.
 	walk := func(path string, info os.FileInfo, err error) error {
 		return gen.walk(path, info, err)
@@ -163,7 +175,7 @@ func (gen *Generator) parseLayout() {
 
 	layout := gen.Config.GetZString("layout")
 	if gen.Layout, err = thtml.New(filepath.Base(layout)).Funcs(helpers).ParseFiles(layout); err != nil {
-		panic(err)
+		gen.recordErr(err)
 	}
 }
 
@@ -173,7 +185,8 @@ func (gen *Generator) loadI18N() {
 	mainlang := gen.Config.GetSection("site").GetString("language")
 	i18nStrings, err := NewI18n(mainlang)
 	if err != nil {
-		panic(err)
+		gen.recordErr(err)
+		return
 	}
 	gen.I18n = &gt.Build{
 		Index:  i18nStrings,
@@ -188,11 +201,12 @@ func (gen *Generator) handleDeployPath(full bool) {
 	// If deployment path already exists, it must be deleted.
 	if _, err := os.Stat(deployPath); err == nil && full {
 		if err = os.RemoveAll(deployPath); err != nil {
-			panic(err)
+			gen.recordErr(err)
+			return
 		}
 	}
 	if err := os.MkdirAll(deployPath, os.FileMode(ZAS_DEFAULT_DIR_PERM)); err != nil {
-		panic(err)
+		gen.recordErr(err)
 	}
 }
 

--- a/i18n_race_test.go
+++ b/i18n_race_test.go
@@ -1,0 +1,47 @@
+package zas
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/melvinmt/gt"
+)
+
+// C2: every render used to share one *gt.Build, racing on SetTarget/
+// Translate's internal fields and letting one page's language bleed into
+// another's. Run under `go test -race`; also asserts each goroutine only
+// ever observes its own language's translation.
+func TestZasDataTranslationConcurrentNoRace(t *testing.T) {
+	index := gt.Strings{
+		"greeting": {"en": "Hello", "es": "Hola", "fr": "Bonjour"},
+	}
+	gen := &Generator{I18n: &gt.Build{Index: index, Origin: "en"}}
+	want := map[string]string{"en": "Hello", "es": "Hola", "fr": "Bonjour"}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(want)*100)
+	for range 100 {
+		for lang, translation := range want {
+			wg.Add(1)
+			go func(lang, translation string) {
+				defer wg.Done()
+				data := NewZasData("page.html", gen)
+				data.i18n.SetTarget(lang)
+				got, err := data.i18n.Translate("greeting")
+				if err != nil {
+					errCh <- fmt.Errorf("lang=%s: %w", lang, err)
+					return
+				}
+				if got != translation {
+					errCh <- fmt.Errorf("lang=%s: Translate() = %q, want %q", lang, got, translation)
+				}
+			}(lang, translation)
+		}
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Error(err)
+	}
+}

--- a/init.go
+++ b/init.go
@@ -86,22 +86,20 @@ func NewI18n(mainlang string) (i18n gt.Strings, err error) {
  * Returns a string value from current section.
  */
 func (cs ConfigSection) GetString(key string) (value string) {
-	raw := cs[key]
-	if raw == nil {
-		value = ""
-	} else {
-		value = raw.(string)
-	}
+	value, _ = cs[key].(string)
 	return
 }
 
 /*
- * Returns a subsection from current section.
+ * Returns a subsection from current section, or nil if key is missing or
+ * not a section.
  */
 func (cs ConfigSection) GetSection(key string) (value ConfigSection) {
-	var ok bool
-	if value, ok = cs[key].(ConfigSection); !ok {
-		value = ConfigSection(cs[key].(map[interface{}]interface{}))
+	switch raw := cs[key].(type) {
+	case ConfigSection:
+		value = raw
+	case map[interface{}]interface{}:
+		value = ConfigSection(raw)
 	}
 	return
 }

--- a/init.go
+++ b/init.go
@@ -60,22 +60,26 @@ func NewConfig() (ConfigSection, error) {
  */
 func NewI18n(mainlang string) (i18n gt.Strings, err error) {
 	data, err := os.ReadFile(ZAS_I18N_FILE)
-	i18n = make(gt.Strings)
 	if err != nil {
 		if os.IsNotExist(err) {
-			err = nil
-			return
+			return make(gt.Strings), nil
 		}
-		i18n = nil
-		return
+		return nil, err
 	}
-	err = yaml.Unmarshal(data, &i18n)
+	i18n = make(gt.Strings)
+	if err = yaml.Unmarshal(data, &i18n); err != nil {
+		return nil, err
+	}
 	for k, v := range i18n {
+		if v == nil {
+			v = make(map[string]string)
+			i18n[k] = v
+		}
 		if _, ok := v[mainlang]; !ok {
 			v[mainlang] = k
 		}
 	}
-	return
+	return i18n, nil
 }
 
 /*

--- a/init.go
+++ b/init.go
@@ -114,7 +114,7 @@ func (cs ConfigSection) GetZString(key string) string {
 
 type Init struct{}
 
-func (i *Init) Run() {
+func (i *Init) Run() error {
 	path, _ := filepath.Abs(ZAS_DIR)
 	if _, err := os.Stat(ZAS_DIR); os.IsNotExist(err) {
 		os.Mkdir(ZAS_DIR, os.FileMode(ZAS_DEFAULT_DIR_PERM))
@@ -130,10 +130,8 @@ func (i *Init) Run() {
 	// It overwrites every time we invoke init subcommand.
 	if len(ZAS_DEFAULT_CONF) > 0 {
 		if data, err = yaml.Marshal(&ZAS_DEFAULT_CONF); err != nil {
-			panic(err)
+			return err
 		}
 	}
-	if err := os.WriteFile(ZAS_CONF_FILE, data, os.FileMode(ZAS_DEFAULT_FILE_PERM)); err != nil {
-		panic(err)
-	}
+	return os.WriteFile(ZAS_CONF_FILE, data, os.FileMode(ZAS_DEFAULT_FILE_PERM))
 }

--- a/init_run_test.go
+++ b/init_run_test.go
@@ -1,0 +1,33 @@
+package zas
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// B1: Init.Run must return an error instead of panicking on a write failure.
+
+func TestInitRunWriteFailureReturnsError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	// Make ZAS_DIR a regular file so os.WriteFile(ZAS_CONF_FILE, ...) - which
+	// treats it as a directory - fails deterministically.
+	if err := os.WriteFile(ZAS_DIR, []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	i := &Init{}
+	if err := i.Run(); err == nil {
+		t.Fatal("Init.Run(): want error, got nil")
+	}
+}
+
+func TestInitRunOK(t *testing.T) {
+	t.Chdir(t.TempDir())
+	i := &Init{}
+	if err := i.Run(); err != nil {
+		t.Fatalf("Init.Run() error = %v, want nil", err)
+	}
+	if _, err := os.Stat(filepath.Join(ZAS_DIR, "config.yml")); err != nil {
+		t.Fatalf("config.yml not written: %v", err)
+	}
+}

--- a/newi18n_test.go
+++ b/newi18n_test.go
@@ -1,0 +1,52 @@
+package zas
+
+import (
+	"os"
+	"testing"
+)
+
+// B4: NewI18n must not panic on an entry with no translations, and must
+// check the yaml.Unmarshal error before the backfill loop runs.
+
+func TestNewI18nNoFile(t *testing.T) {
+	t.Chdir(t.TempDir())
+	i18n, err := NewI18n("en")
+	if err != nil {
+		t.Fatalf("NewI18n() error = %v, want nil", err)
+	}
+	if len(i18n) != 0 {
+		t.Fatalf("NewI18n() = %v, want empty", i18n)
+	}
+}
+
+func TestNewI18nNilMapEntry(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.MkdirAll(ZAS_DIR, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(ZAS_I18N_FILE, []byte("Some key:\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	i18n, err := NewI18n("en")
+	if err != nil {
+		t.Fatalf("NewI18n() error = %v, want nil", err)
+	}
+	if got := i18n["Some key"]["en"]; got != "Some key" {
+		t.Fatalf("i18n[%q][%q] = %q, want %q", "Some key", "en", got, "Some key")
+	}
+}
+
+func TestNewI18nMalformedYAML(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.MkdirAll(ZAS_DIR, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(ZAS_I18N_FILE, []byte("not: valid: yaml: [\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewI18n("en"); err == nil {
+		t.Fatal("NewI18n() with malformed YAML: want error, got nil")
+	}
+}

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -1,0 +1,115 @@
+package zas
+
+import (
+	"testing"
+
+	"github.com/melvinmt/gt"
+)
+
+// B3: Resolve must error on a present-but-non-string value instead of
+// panicking on the `.(string)` assertion, while still falling back to ""
+// when the key is genuinely absent.
+
+func TestResolveMissingKeyFallsBackToEmpty(t *testing.T) {
+	zd := &ZasData{
+		Page:   map[interface{}]interface{}{},
+		config: ConfigSection{},
+	}
+	got, err := zd.Resolve("language")
+	if err != nil {
+		t.Fatalf("Resolve() error = %v, want nil", err)
+	}
+	if got != "" {
+		t.Fatalf("Resolve() = %q, want empty string", got)
+	}
+}
+
+func TestResolveNilPageValueErrors(t *testing.T) {
+	// e.g. <!-- language: --> (YAML null) in a page's config comment.
+	zd := &ZasData{
+		Page: map[interface{}]interface{}{"language": nil},
+	}
+	if _, err := zd.Resolve("language"); err == nil {
+		t.Fatal("Resolve() with nil page value: want error, got nil")
+	}
+}
+
+func TestResolveNonStringPageValueErrors(t *testing.T) {
+	// e.g. language: 5 in a page's config comment.
+	zd := &ZasData{
+		Page: map[interface{}]interface{}{"language": 5},
+	}
+	if _, err := zd.Resolve("language"); err == nil {
+		t.Fatal("Resolve() with numeric page value: want error, got nil")
+	}
+}
+
+func TestResolveDirectoryFallback(t *testing.T) {
+	zd := &ZasData{
+		Page:      map[interface{}]interface{}{},
+		Directory: ConfigSection{"language": "es"},
+	}
+	got, err := zd.Resolve("language")
+	if err != nil {
+		t.Fatalf("Resolve() error = %v, want nil", err)
+	}
+	if got != "es" {
+		t.Fatalf("Resolve() = %q, want %q", got, "es")
+	}
+}
+
+func TestLanguagePropagatesResolveError(t *testing.T) {
+	zd := &ZasData{Page: map[interface{}]interface{}{"language": 5}}
+	if _, err := zd.Language(); err == nil {
+		t.Fatal("Language(): want error, got nil")
+	}
+}
+
+func TestIsHomePropagatesLanguageError(t *testing.T) {
+	zd := &ZasData{Path: "/index.html", Page: map[interface{}]interface{}{"language": 5}}
+	if _, err := zd.IsHome(); err == nil {
+		t.Fatal("IsHome(): want error, got nil")
+	}
+}
+
+func TestIsHomeOK(t *testing.T) {
+	zd := &ZasData{
+		Path:   "/index.html",
+		Page:   map[interface{}]interface{}{},
+		config: ConfigSection{},
+	}
+	home, err := zd.IsHome()
+	if err != nil {
+		t.Fatalf("IsHome() error = %v, want nil", err)
+	}
+	if !home {
+		t.Fatal("IsHome() = false, want true for /index.html")
+	}
+}
+
+func TestEPropagatesLanguageError(t *testing.T) {
+	zd := &ZasData{
+		Page: map[interface{}]interface{}{"language": 5},
+		i18n: &gt.Build{},
+	}
+	if _, err := zd.E("greeting"); err == nil {
+		t.Fatal("E(): want error, got nil")
+	}
+}
+
+func TestEFallsBackOnMissingTranslation(t *testing.T) {
+	// A missing translation key must still render as "**key**" rather than
+	// being treated as an error - only a bad page-config value should abort
+	// the render.
+	zd := &ZasData{
+		Page: map[interface{}]interface{}{"language": "en"},
+		i18n: &gt.Build{Index: gt.Strings{}, Origin: "en"},
+	}
+	got, err := zd.E("missing.key")
+	if err != nil {
+		t.Fatalf("E() error = %v, want nil", err)
+	}
+	if want := "**missing.key**"; got != want {
+		t.Fatalf("E() = %q, want %q", got, want)
+	}
+}

--- a/walk_test.go
+++ b/walk_test.go
@@ -1,0 +1,25 @@
+package zas
+
+import (
+	"errors"
+	"testing"
+)
+
+// B5: walk/reaper must return the incoming filepath.Walk error immediately,
+// instead of touching a possibly-nil FileInfo first.
+
+func TestWalkPropagatesErr(t *testing.T) {
+	gen := &Generator{}
+	wantErr := errors.New("permission denied")
+	if err := gen.walk("noperm", nil, wantErr); !errors.Is(err, wantErr) {
+		t.Fatalf("walk() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestReaperPropagatesErr(t *testing.T) {
+	gen := &Generator{}
+	wantErr := errors.New("permission denied")
+	if err := gen.reaper("noperm", nil, wantErr); !errors.Is(err, wantErr) {
+		t.Fatalf("reaper() error = %v, want %v", err, wantErr)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two data races and seven panic-on-input crashes found during an internal review of the generation pipeline:

- `cachedZasDirectoryConfigs` was read/written from every per-file render goroutine with no synchronization (`fatal error: concurrent map writes`). Guarded with a dedicated mutex.
- Every render shared one `*gt.Build` i18n instance, racing on `SetTarget`/`Translate`'s internal fields and letting one page's language bleed into another's. Each render now gets its own `*gt.Build` sharing only the read-only translation index.
- Startup steps (layout parsing, i18n loading, deploy-path setup, and `init`) panicked on ordinary setup errors — e.g. the very first `zas` run after `zas init`, since `init` doesn't scaffold `layout.html`. Now return/record errors, surfaced through the existing exit-code path instead of a raw stack trace.
- Config getters (`GetString`/`GetSection`) panicked on a missing or wrongly-typed config key. Now fall back to zero values.
- Page-config resolution (`Resolve`, and everything built on it: `Language`/`IsHome`/`E`/`H`) panicked on a non-string page-config value (e.g. an empty `language:` comment). Now return errors that abort just that page's render via Go's template `(value, error)` convention, rather than crashing the whole build.
- i18n loading wrote into a nil map for a translation key with no values, and ran that logic before checking the YAML unmarshal error.
- The file-walk callbacks ignored their incoming error and dereferenced a nil `FileInfo` (e.g. hitting an unreadable directory).
- The embed-tag plugin dispatch used reflection to call a config-selected method by name without validating its signature, so a config value could resolve to a real method with the wrong shape and panic inside `reflect.Value.Call`. Now signature-validated before calling.
- Incremental-mode freshness checking discarded a `Stat` error and dereferenced the resulting nil `FileInfo`.

Each fix lands as its own atomic commit (validated with `darna`) alongside its regression test — the repo previously had zero tests.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` (all new tests pass under the race detector — the actual proof the two races are fixed)
- [x] Verified the race tests fail under `-race` when their fixes are reverted (negative control)
- [x] Manual repro: `zas init` in an empty dir, then `zas` with no `.zas/layout.html` → clean `fatal: ...` message and exit 1, no stack trace