### PR TITLE
fix: i18n interpolation, text/plain embeds, page-template methods, MIME plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ mimetypes:
   text/yaml+myplugin: myplugin
 ```
 
-If Zas finds an embed tag with a type attribute set to `text/yaml+myplugin`, it will invoke `mzsmyplugin`. Zas expects to process the plugin's stdout as HTML. It also pipes stderr to the user's shell. Any plugin will be called passing the current file's path as an argument.
+If Zas finds an embed tag with a type attribute set to `text/yaml+myplugin`, it will invoke `mzsmyplugin`. Zas expects to process the plugin's stdout as HTML. It also pipes stderr to the user's shell. Any plugin will be called with the embed's `src` attribute as its only argument, resolved relative to the site's root rather than to the file containing the `<embed>` tag.
 
 ```html
 <embed src="navigation.md" type="text/markdown" />

--- a/data.go
+++ b/data.go
@@ -139,11 +139,7 @@ func (zd *ZasData) E(s string, a ...interface{}) (t string, err error) {
 		return "", err
 	}
 	zd.i18n.SetTarget(lang)
-	if len(a) == 0 {
-		t, err = zd.i18n.Translate(s)
-	} else {
-		t, err = zd.i18n.Translate(s, a)
-	}
+	t, err = zd.i18n.Translate(s, a...)
 	if err != nil {
 		t = "**" + s + "**"
 		err = nil

--- a/generate.go
+++ b/generate.go
@@ -28,6 +28,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"strings"
 	"sync"
 	ttext "text/template"
@@ -582,7 +583,7 @@ func (gen *Generator) handleEmbedTags(doc *goquery.Document, data *ZasData) (err
 			plugin := gen.resolveMIMETypePlugin(typ)
 			method := reflect.ValueOf(gen).MethodByName(cases.Title(language.English).String(plugin))
 			if !isEmbedPluginMethod(method) {
-				err = gen.handleMIMETypePlugin(e, doc)
+				err = gen.handleMIMETypePlugin(e)
 			} else {
 				args := make([]reflect.Value, 3)
 				args[0] = reflect.ValueOf(e)
@@ -631,53 +632,39 @@ func isEmbedPluginMethod(method reflect.Value) bool {
 	return true
 }
 
-type bufErr struct {
-	buffer []byte
-	err    error
-}
+// pluginNameRe restricts resolved plugin names to safe exec.Command argv[0]
+// suffixes. Without it, a mimetypes entry like {text/x: "../../evil"} would
+// make exec.Command skip PATH lookup and run a path relative to the working
+// directory - and mimetypes config is repo content, so this closes a code
+// execution hole for anyone who can send a pull request.
+var pluginNameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
 /*
- * Invokes a MIME type plugin based on current node's type attribute, passing src attribute's value
- * as argument. Subcommand's output is piped to Gokogiri through a buffer.
+ * Invokes a MIME type plugin based on current node's type attribute, passing
+ * src attribute's value as argument. Subcommand's stdout replaces the embed
+ * tag as HTML; stderr is passed through to the user's shell.
  */
-func (gen *Generator) handleMIMETypePlugin(e *goquery.Selection, doc *goquery.Document) (err error) {
-	var (
-		src, typ string
-		ok       bool
-	)
-	if src, ok = e.Attr(atom.Src.String()); ok {
-		return
+func (gen *Generator) handleMIMETypePlugin(e *goquery.Selection) error {
+	src, ok := e.Attr(atom.Src.String())
+	if !ok {
+		return errors.New("missing src attribute for embed")
 	}
-	if typ, ok = e.Attr(atom.Type.String()); ok {
-		return
+	typ, ok := e.Attr(atom.Type.String())
+	if !ok {
+		return fmt.Errorf("missing type attribute for embed %q", src)
 	}
 	cmdname := gen.resolveMIMETypePlugin(typ)
-	if cmdname == "" {
-		return
+	if !pluginNameRe.MatchString(cmdname) {
+		return fmt.Errorf("no valid plugin configured for embed type %q (src %q)", typ, src)
 	}
 	cmd := exec.Command(fmt.Sprintf("m%s%s", ZAS_PREFIX, cmdname), src)
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return
-	}
 	cmd.Stderr = os.Stderr
-	c := make(chan bufErr)
-	go func() {
-		data, err := io.ReadAll(stdout)
-		c <- bufErr{data, err}
-	}()
-	if err = cmd.Start(); err != nil {
-		return
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("plugin m%s%s failed for %q: %w", ZAS_PREFIX, cmdname, src, err)
 	}
-	be := <-c
-	if err = cmd.Wait(); err != nil {
-		return
-	}
-	if be.err != nil {
-		return be.err
-	}
-	e.ReplaceWithHtml(string(be.buffer))
-	return
+	e.ReplaceWithHtml(string(out))
+	return nil
 }
 
 /*

--- a/generate.go
+++ b/generate.go
@@ -398,7 +398,10 @@ func (gen *Generator) render(path string, input []byte) (err error) {
 	// Building context and rendering template.
 	data := NewZasData(path, gen)
 	data.Directory, _ = gen.loadZasDirectoryConfig(path)
-	if err = template.Execute(&processed, data); err != nil {
+	// Pass a pointer: text/template only sees pointer-receiver methods
+	// (Title, E, URL, ...) on an addressable value, and a plain "data" here
+	// is not addressable.
+	if err = template.Execute(&processed, &data); err != nil {
 		return
 	}
 	doc, err := gen.parseAndReplace(processed, &data)

--- a/generate.go
+++ b/generate.go
@@ -538,8 +538,7 @@ func (gen *Generator) Plain(e *goquery.Selection, doc *goquery.Document, data *Z
 		if err = template.Execute(&processed, data); err != nil {
 			return
 		}
-		e.Parent().Nodes[0].Data = processed.String()
-		e.Remove()
+		e.ReplaceWithNodes(&html5.Node{Type: html5.TextNode, Data: processed.String()})
 	}
 	return
 }

--- a/i18n_args_test.go
+++ b/i18n_args_test.go
@@ -1,0 +1,66 @@
+package zas
+
+import (
+	thtml "html/template"
+	"testing"
+
+	"github.com/melvinmt/gt"
+)
+
+// Translate's arguments must be spread into gt.Translate's variadic
+// parameter, not passed as a single []interface{} value - otherwise fmt's
+// verbs only ever see one argument (the slice itself), and any string with
+// more than one verb fails gt's verb/argument count check entirely.
+
+func TestESpreadsSingleArgument(t *testing.T) {
+	zd := &ZasData{
+		Page: map[interface{}]interface{}{"language": "en"},
+		i18n: &gt.Build{
+			Index:  gt.Strings{"Hello %s": {"en": "Hello %s"}},
+			Origin: "en",
+		},
+	}
+	got, err := zd.E("Hello %s", "World")
+	if err != nil {
+		t.Fatalf("E() error = %v, want nil", err)
+	}
+	if want := "Hello World"; got != want {
+		t.Fatalf("E() = %q, want %q", got, want)
+	}
+}
+
+func TestESpreadsMultipleArguments(t *testing.T) {
+	zd := &ZasData{
+		Page: map[interface{}]interface{}{"language": "en"},
+		i18n: &gt.Build{
+			Index: gt.Strings{
+				"greeting": {"en": "Hello %s, you have %s messages"},
+			},
+			Origin: "en",
+		},
+	}
+	got, err := zd.E("greeting", "World", "3")
+	if err != nil {
+		t.Fatalf("E() error = %v, want nil", err)
+	}
+	if want := "Hello World, you have 3 messages"; got != want {
+		t.Fatalf("E() = %q, want %q", got, want)
+	}
+}
+
+func TestHSpreadsArguments(t *testing.T) {
+	zd := &ZasData{
+		Page: map[interface{}]interface{}{"language": "en"},
+		i18n: &gt.Build{
+			Index:  gt.Strings{"Hello %s": {"en": "Hello %s"}},
+			Origin: "en",
+		},
+	}
+	got, err := zd.H("Hello %s", "World")
+	if err != nil {
+		t.Fatalf("H() error = %v, want nil", err)
+	}
+	if want := thtml.HTML("Hello World"); got != want {
+		t.Fatalf("H() = %q, want %q", got, want)
+	}
+}

--- a/mime_plugin_test.go
+++ b/mime_plugin_test.go
@@ -1,0 +1,89 @@
+package zas
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+// The src/type attribute checks were inverted (returning early exactly when
+// the attributes were present), so handleMIMETypePlugin could never reach
+// the point of invoking an external plugin - the whole mzs* plugin feature
+// was unreachable.
+
+func newEmbedDoc(t *testing.T, src, typ string) *goquery.Document {
+	t.Helper()
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(
+		`<div><embed src="` + src + `" type="` + typ + `"></div>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return doc
+}
+
+func TestHandleMIMETypePluginRunsExternalCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script plugin stub is not portable to windows")
+	}
+	bin := t.TempDir()
+	script := "#!/bin/sh\necho '<b>ok</b>'\n"
+	if err := os.WriteFile(filepath.Join(bin, "mzstest"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin)
+
+	gen := &Generator{Config: ConfigSection{
+		"mimetypes": ConfigSection{"text/x-test": "test"},
+	}}
+	doc := newEmbedDoc(t, "x", "text/x-test")
+	if err := gen.handleMIMETypePlugin(doc.Find("embed")); err != nil {
+		t.Fatalf("handleMIMETypePlugin() error = %v, want nil", err)
+	}
+	if got := doc.Find("b").Text(); got != "ok" {
+		t.Fatalf("plugin output not spliced into the document: got %q", got)
+	}
+	if doc.Find("embed").Length() != 0 {
+		t.Fatal("embed tag still present after handleMIMETypePlugin()")
+	}
+}
+
+func TestHandleMIMETypePluginMissingBinaryReturnsError(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	gen := &Generator{Config: ConfigSection{
+		"mimetypes": ConfigSection{"text/x-missing": "doesnotexist"},
+	}}
+	doc := newEmbedDoc(t, "x", "text/x-missing")
+	if err := gen.handleMIMETypePlugin(doc.Find("embed")); err == nil {
+		t.Fatal("handleMIMETypePlugin() with no matching binary on PATH: want error, got nil")
+	}
+}
+
+func TestHandleMIMETypePluginUnconfiguredTypeReturnsError(t *testing.T) {
+	gen := &Generator{Config: ConfigSection{"mimetypes": ConfigSection{}}}
+	doc := newEmbedDoc(t, "x", "text/x-nope")
+	err := gen.handleMIMETypePlugin(doc.Find("embed"))
+	if err == nil {
+		t.Fatal("handleMIMETypePlugin() with an unconfigured type: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "text/x-nope") {
+		t.Fatalf("error = %v, want it to mention the embed type", err)
+	}
+}
+
+func TestHandleMIMETypePluginRejectsPathSeparator(t *testing.T) {
+	gen := &Generator{Config: ConfigSection{
+		"mimetypes": ConfigSection{"text/x-evil": "../../evil"},
+	}}
+	doc := newEmbedDoc(t, "x", "text/x-evil")
+	err := gen.handleMIMETypePlugin(doc.Find("embed"))
+	if err == nil {
+		t.Fatal("handleMIMETypePlugin() with a path-separator plugin name: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no valid plugin") {
+		t.Fatalf("error = %v, want the name rejected before exec", err)
+	}
+}

--- a/page_data_test.go
+++ b/page_data_test.go
@@ -1,0 +1,66 @@
+package zas
+
+import (
+	thtml "html/template"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	ttext "text/template"
+
+	"github.com/melvinmt/gt"
+)
+
+// text/template only exposes pointer-receiver methods (Title, URL, E, H,
+// IsHome, Resolve, Extra) on an addressable value. render used to pass
+// ZasData by value to the page template, so every one of those methods
+// failed template execution outright when called from a page body - even
+// though the identical expression works in the layout, which does receive a
+// pointer.
+
+func TestZasDataPointerMethodsNeedAddressableValue(t *testing.T) {
+	tmpl, err := ttext.New("t").Parse(`{{.URL}}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zd := ZasData{Path: "/index.html"}
+
+	if err := tmpl.Execute(io.Discard, zd); err == nil {
+		t.Fatal("Execute() against a value: want error, got nil")
+	}
+	if err := tmpl.Execute(io.Discard, &zd); err != nil {
+		t.Fatalf("Execute() against a pointer: error = %v, want nil", err)
+	}
+}
+
+func TestRenderPageBodyCanCallPointerReceiverMethod(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.MkdirAll("deploy", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gen := &Generator{
+		Config: ConfigSection{
+			"zas":  ConfigSection{"deploy": "deploy"},
+			"site": ConfigSection{"baseurl": "http://example.com"},
+		},
+		I18n: &gt.Build{Index: gt.Strings{}, Origin: "en"},
+	}
+	layout, err := thtml.New("layout").Funcs(helpers).Parse(`{{.Body}}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gen.Layout = layout
+
+	if err := gen.render("page.html", []byte(`<body>{{.URL}}</body>`)); err != nil {
+		t.Fatalf("render() error = %v, want nil", err)
+	}
+
+	out, err := os.ReadFile(filepath.Join("deploy", "page.html"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "http://example.com/page.html"; !strings.Contains(string(out), want) {
+		t.Fatalf("deployed output = %q, want it to contain %q", out, want)
+	}
+}

--- a/plain_embed_test.go
+++ b/plain_embed_test.go
@@ -1,0 +1,99 @@
+package zas
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+// Plain embeds must insert the rendered file as a text node. html.Node.Data
+// holds the tag name for an ElementNode, not its text content, so writing
+// straight into the parent's Data field renamed the parent tag instead of
+// inserting text.
+
+func TestPlainEmbedDoesNotRenameParentTag(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile("note.txt", []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(
+		`<div><embed src="note.txt" type="text/plain"></div>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gen := &Generator{}
+	if err := gen.Plain(doc.Find("embed"), doc, &ZasData{}); err != nil {
+		t.Fatalf("Plain() error = %v, want nil", err)
+	}
+	div := doc.Find("div")
+	if div.Length() != 1 {
+		t.Fatalf("div elements = %d, want 1 (parent tag must survive)", div.Length())
+	}
+	if got := goquery.NodeName(div); got != "div" {
+		t.Fatalf("parent tag = %q, want %q", got, "div")
+	}
+}
+
+func TestPlainEmbedInsertsEscapedText(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile("note.txt", []byte("Hello <b>World</b>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(
+		`<div><embed src="note.txt" type="text/plain"></div>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gen := &Generator{}
+	if err := gen.Plain(doc.Find("embed"), doc, &ZasData{}); err != nil {
+		t.Fatalf("Plain() error = %v, want nil", err)
+	}
+	div := doc.Find("div")
+	if div.Children().Length() != 0 {
+		t.Fatalf("div has %d child elements, want 0 - embedded text must not become markup", div.Children().Length())
+	}
+	if got, want := div.Text(), "Hello <b>World</b>"; got != want {
+		t.Fatalf("div.Text() = %q, want %q", got, want)
+	}
+}
+
+func TestPlainEmbedExecutesTemplate(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile("note.txt", []byte("path is {{.Path}}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(
+		`<div><embed src="note.txt" type="text/plain"></div>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gen := &Generator{}
+	data := &ZasData{Path: "/about.html"}
+	if err := gen.Plain(doc.Find("embed"), doc, data); err != nil {
+		t.Fatalf("Plain() error = %v, want nil", err)
+	}
+	if want, got := "path is /about.html", doc.Find("div").Text(); got != want {
+		t.Fatalf("div.Text() = %q, want %q", got, want)
+	}
+}
+
+func TestPlainEmbedRemovesEmbedTag(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile("note.txt", []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(
+		`<div><embed src="note.txt" type="text/plain"></div>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gen := &Generator{}
+	if err := gen.Plain(doc.Find("embed"), doc, &ZasData{}); err != nil {
+		t.Fatalf("Plain() error = %v, want nil", err)
+	}
+	if doc.Find("embed").Length() != 0 {
+		t.Fatal("embed tag still present after Plain()")
+	}
+}


### PR DESCRIPTION
## Summary

Four independent fixes to features that were documented but silently broken:

- **i18n argument interpolation.** `{{.E "Hello %s" "World"}}` rendered as `Hello [World]`, and any translation with more than one substitution failed outright. The translation call was passing its arguments as one slice value instead of spreading them.
- **`text/plain` embeds.** `<embed src="note.txt" type="text/plain" />` corrupted the surrounding markup: the code wrote the embedded text into the parent element's tag name instead of inserting a text node, so serialization emitted a garbage tag.
- **Page templates couldn't call most `ZasData` methods.** `{{.Title}}`, `{{.URL}}`, `{{.E}}`, `{{.H}}`, `{{.IsHome}}`, `{{.Resolve}}`, and `{{.Extra}}` all hard-errored the page render when used in a page body (though they worked fine in the layout). Go's `text/template` only sees pointer-receiver methods on an addressable value, and the page template was executed against a plain value instead of a pointer.
- **External MIME-type plugins (the `mzs*` binaries described in the README) could never run.** An attribute check was inverted so the dispatch function returned immediately whenever the embed actually had the attributes needed to invoke a plugin. While fixing this, the hand-rolled stdout-piping code was replaced with `cmd.Output()` (simpler, and it removes a goroutine leak when the plugin binary fails to start), and the resolved plugin name is now validated against a strict allowlist before being used to build a command - `mimetypes` is repository-controlled config, and an unvalidated name could otherwise execute an arbitrary relative path. An embed whose type has no matching plugin now fails the build instead of silently leaving a raw `<embed>` tag in the output.

Each commit is independent and can be reviewed/reverted on its own.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -race` (27 tests, all passing)
- [x] `gofmt -l` on all changed Go files
- [x] Each bug has a regression test that fails against the pre-fix code (verified manually by reverting each change in isolation)
