### PR TITLE
fix: scope raw-HTML passthrough, preserve body attrs, cap embed depth

### DIFF
--- a/body_attrs_test.go
+++ b/body_attrs_test.go
@@ -1,0 +1,81 @@
+package zas
+
+import (
+	thtml "html/template"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/melvinmt/gt"
+)
+
+// data.Body carries only a source page's inner HTML, not its <body>
+// element, since nesting a full <body> inside the layout's own <body>
+// produced doubled elements. That means any attributes on the source's own
+// <body> tag (e.g. a per-page id or data attribute) need to be merged onto
+// the layout's <body> explicitly, or they're silently lost. The layout's
+// own attributes win on a colliding key.
+
+func TestRenderPreservesSourceBodyAttributes(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.MkdirAll("deploy", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gen := &Generator{
+		Config: ConfigSection{"zas": ConfigSection{"deploy": "deploy"}},
+		I18n:   &gt.Build{Index: gt.Strings{}, Origin: "en"},
+	}
+	layout, err := thtml.New("layout").Funcs(helpers).Parse(`<body class="layout">{{.Body}}</body>`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gen.Layout = layout
+
+	src := `<body id="special" data-x="1" class="source">content</body>`
+	if err := gen.render("page.html", []byte(src)); err != nil {
+		t.Fatalf("render() error = %v, want nil", err)
+	}
+
+	out, err := os.ReadFile(filepath.Join("deploy", "page.html"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	for _, want := range []string{`id="special"`, `data-x="1"`, `class="layout"`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output = %q, want it to contain %q", got, want)
+		}
+	}
+	if strings.Contains(got, `class="source"`) {
+		t.Fatalf("output = %q, want the layout's class to win over the source's", got)
+	}
+}
+
+func TestRenderWithoutSourceBodyAttributesLeavesLayoutUnchanged(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.MkdirAll("deploy", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gen := &Generator{
+		Config: ConfigSection{"zas": ConfigSection{"deploy": "deploy"}},
+		I18n:   &gt.Build{Index: gt.Strings{}, Origin: "en"},
+	}
+	layout, err := thtml.New("layout").Funcs(helpers).Parse(`<body class="layout">{{.Body}}</body>`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gen.Layout = layout
+
+	if err := gen.render("page.html", []byte(`<body>content</body>`)); err != nil {
+		t.Fatalf("render() error = %v, want nil", err)
+	}
+
+	out, err := os.ReadFile(filepath.Join("deploy", "page.html"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := `class="layout"`; !strings.Contains(string(out), want) {
+		t.Fatalf("output = %q, want it to contain %q", out, want)
+	}
+}

--- a/clean_p_tags_test.go
+++ b/clean_p_tags_test.go
@@ -1,0 +1,82 @@
+package zas
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+// html.Node.Data holds the tag name for an ElementNode, not its text
+// content, so reading it to decide whether a <p> was "visually empty" always
+// saw the literal string "p" - the removal branch below could never run.
+
+func parseFragment(t *testing.T, html string) *goquery.Document {
+	t.Helper()
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return doc
+}
+
+func TestCleanUnnecessaryPTagsRemovesChildlessParagraph(t *testing.T) {
+	// The artifact HTML5 parser error recovery leaves behind when a block
+	// element inline inside a Markdown paragraph implicitly closes it.
+	doc := parseFragment(t, `<p></p><div>Hello world!</div><p></p>`)
+	gen := &Generator{}
+	gen.cleanUnnecessaryPTags(doc)
+	if doc.Find("p").Length() != 0 {
+		t.Fatalf("p elements = %d, want 0", doc.Find("p").Length())
+	}
+	if doc.Find("div").Length() != 1 {
+		t.Fatalf("div elements = %d, want 1 (must survive untouched)", doc.Find("div").Length())
+	}
+}
+
+func TestCleanUnnecessaryPTagsKeepsTextParagraph(t *testing.T) {
+	doc := parseFragment(t, `<p>Hello world!</p>`)
+	gen := &Generator{}
+	gen.cleanUnnecessaryPTags(doc)
+	if doc.Find("p").Length() != 1 {
+		t.Fatalf("p elements = %d, want 1", doc.Find("p").Length())
+	}
+}
+
+func TestCleanUnnecessaryPTagsKeepsSingleChildParagraph(t *testing.T) {
+	// A <p> whose only child is an element (not a removal target) must
+	// survive: unwrapping it would change ordinary Markdown paragraph
+	// semantics such as <p><strong>bold sentence</strong></p>.
+	doc := parseFragment(t, `<p><strong>bold sentence</strong></p>`)
+	gen := &Generator{}
+	gen.cleanUnnecessaryPTags(doc)
+	if doc.Find("p").Length() != 1 {
+		t.Fatalf("p elements = %d, want 1", doc.Find("p").Length())
+	}
+	if doc.Find("strong").Length() != 1 {
+		t.Fatalf("strong elements = %d, want 1", doc.Find("strong").Length())
+	}
+}
+
+func TestCleanUnnecessaryPTagsKeepsImageOnlyParagraph(t *testing.T) {
+	doc := parseFragment(t, `<p><img src="x.png"></p>`)
+	gen := &Generator{}
+	gen.cleanUnnecessaryPTags(doc)
+	if doc.Find("p").Length() != 1 {
+		t.Fatalf("p elements = %d, want 1", doc.Find("p").Length())
+	}
+	if doc.Find("img").Length() != 1 {
+		t.Fatalf("img elements = %d, want 1", doc.Find("img").Length())
+	}
+}
+
+func TestCleanUnnecessaryPTagsKeepsNbspParagraph(t *testing.T) {
+	// A non-breaking space is a real (if invisible) text node, and a common
+	// spacer idiom - it must not be treated the same as a childless <p>.
+	doc := parseFragment(t, `<p>&nbsp;</p>`)
+	gen := &Generator{}
+	gen.cleanUnnecessaryPTags(doc)
+	if doc.Find("p").Length() != 1 {
+		t.Fatalf("p elements = %d, want 1", doc.Find("p").Length())
+	}
+}

--- a/data.go
+++ b/data.go
@@ -47,6 +47,10 @@ type ZasData struct {
 	config ConfigSection
 	// i18n helper
 	i18n *gt.Build
+	// Attributes from the source page's own <body> tag (if any), merged
+	// onto the layout's <body> element since Body only carries the source
+	// body's inner HTML, not the element itself.
+	bodyAttrs map[string]string
 }
 
 /*

--- a/data.go
+++ b/data.go
@@ -51,6 +51,9 @@ type ZasData struct {
 	// onto the layout's <body> element since Body only carries the source
 	// body's inner HTML, not the element itself.
 	bodyAttrs map[string]string
+	// Tracks embed nesting depth for this render, guarding against a self-
+	// or mutually-embedding file recursing without bound.
+	embedDepth int
 }
 
 /*

--- a/embed_depth_test.go
+++ b/embed_depth_test.go
@@ -1,0 +1,33 @@
+package zas
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/melvinmt/gt"
+)
+
+// A file that embeds itself (directly, or through a cycle of mutually-
+// embedding files) recurses through parseAndReplace/handleEmbedTags without
+// bound now that raw HTML - including <embed> tags written in a .md source -
+// is no longer dropped by the Markdown converter. This must fail with an
+// error instead of exhausting the goroutine's stack.
+
+func TestRenderMarkdownSelfEmbedReturnsError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile("self.md", []byte(`<embed src="self.md" type="text/markdown" />`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gen := &Generator{
+		Config: ConfigSection{"mimetypes": ConfigSection{"text/markdown": "markdown"}},
+		I18n:   &gt.Build{Index: gt.Strings{}, Origin: "en"},
+	}
+	err := gen.renderMarkdown("self.md")
+	if err == nil {
+		t.Fatal("renderMarkdown() on a self-embedding file: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "embed nesting") {
+		t.Fatalf("error = %v, want it to report excessive embed nesting", err)
+	}
+}

--- a/generate.go
+++ b/generate.go
@@ -160,6 +160,18 @@ func (gen *Generator) Generate(path string, data *ZasData) (err error) {
 	if err != nil {
 		return
 	}
+	if len(data.bodyAttrs) > 0 {
+		// Body only carries the source page's inner HTML, not its <body>
+		// element, so its attributes need to be merged onto the layout's
+		// <body> explicitly. Non-colliding only: the layout's own attribute
+		// wins on a key both define.
+		layoutBody := doc.Find(atom.Body.String())
+		for key, val := range data.bodyAttrs {
+			if _, exists := layoutBody.Attr(key); !exists {
+				layoutBody.SetAttr(key, val)
+			}
+		}
+	}
 	f, err := os.OpenFile(gen.BuildDeployPath(data.Path), os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(ZAS_DEFAULT_FILE_PERM))
 	if err != nil {
 		return
@@ -479,6 +491,12 @@ func (gen *Generator) render(path string, input []byte) (err error) {
 			return
 		}
 		data.Body = thtml.HTML(strings.TrimSpace(bodyHTML))
+		if attrs := body.Get(0).Attr; len(attrs) > 0 {
+			data.bodyAttrs = make(map[string]string, len(attrs))
+			for _, a := range attrs {
+				data.bodyAttrs[a.Key] = a.Val
+			}
+		}
 	}
 	return gen.Generate(path, &data)
 }

--- a/generate.go
+++ b/generate.go
@@ -514,21 +514,15 @@ func (gen *Generator) render(path string, input []byte) (err error) {
 }
 
 /*
- * Removes unnecessary paragraph HTML tags generated during Markdown processing by
- * deleting any <p> without child text nodes (just to avoid deletion if semantic tags
- * are inside).
+ * Removes <p> elements left completely empty by HTML5 parser error
+ * recovery: a block element written inline inside a Markdown paragraph
+ * implicitly closes it, and the parser synthesizes an empty <p></p> from
+ * the orphaned closing tag.
  */
 func (gen *Generator) cleanUnnecessaryPTags(doc *goquery.Document) {
 	doc.Find(atom.P.String()).Each(func(ix int, p *goquery.Selection) {
-		hasText := false
-		// Little heuristic to remove nodes with visually empty content.
-		content := strings.TrimSpace(p.Nodes[0].Data)
-		if content != "" {
-			hasText = true
-		}
-		// If current <p> tag doesn't have any child text node, extract children and add to its parent.
-		if !hasText {
-			p.ReplaceWithSelection(p.Children())
+		if p.Nodes[0].FirstChild == nil {
+			p.Remove()
 		}
 	})
 }

--- a/generate.go
+++ b/generate.go
@@ -36,7 +36,9 @@ import (
 	"github.com/PuerkitoBio/goquery"
 	"github.com/melvinmt/gt"
 	markdown "github.com/yuin/goldmark"
-	htmlrenderer "github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/util"
 	html5 "golang.org/x/net/html"
 	"golang.org/x/net/html/atom"
 	"golang.org/x/text/cases"
@@ -48,6 +50,54 @@ var helpers = thtml.FuncMap{
 	"noescape": noescape,
 	"eq":       eq,
 }
+
+// rawHTMLRenderer overrides only goldmark's raw-HTML node kinds (block and
+// inline) to pass their source through unchanged, instead of the default
+// renderer's "<!-- raw HTML omitted -->" placeholder. Unlike
+// html.WithUnsafe(), this leaves every other renderer - including the ones
+// that sanitize link and image destinations against javascript:/data:/etc.
+// URLs - on their default, safe behavior. It's registered at a lower
+// priority number than the default HTML renderer (1000), which wins ties.
+type rawHTMLRenderer struct{}
+
+func (r *rawHTMLRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(ast.KindHTMLBlock, r.renderHTMLBlock)
+	reg.Register(ast.KindRawHTML, r.renderRawHTML)
+}
+
+func (r *rawHTMLRenderer) renderHTMLBlock(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	n := node.(*ast.HTMLBlock)
+	if entering {
+		for i := 0; i < n.Lines().Len(); i++ {
+			line := n.Lines().At(i)
+			_, _ = w.Write(line.Value(source))
+		}
+	} else if n.HasClosure() {
+		_, _ = w.Write(n.ClosureLine.Value(source))
+	}
+	return ast.WalkContinue, nil
+}
+
+func (r *rawHTMLRenderer) renderRawHTML(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkSkipChildren, nil
+	}
+	n := node.(*ast.RawHTML)
+	for i := 0; i < n.Segments.Len(); i++ {
+		segment := n.Segments.At(i)
+		_, _ = w.Write(segment.Value(source))
+	}
+	return ast.WalkSkipChildren, nil
+}
+
+// markdownConverter passes raw HTML through instead of dropping it - a
+// leading HTML comment (per-page config) and an <embed> tag written
+// directly in a .md file would otherwise never reach Zas. Built once at
+// package init and shared across renderAsync goroutines: goldmark builds a
+// fresh parse context per Convert call, so this is safe for concurrent use.
+var markdownConverter = markdown.New(markdown.WithRendererOptions(
+	renderer.WithNodeRenderers(util.Prioritized(&rawHTMLRenderer{}, 100)),
+))
 
 /*
  * Convenience type to group relevant rendering info.
@@ -321,7 +371,7 @@ func (gen *Generator) renderMarkdown(path string) (err error) {
 	}
 	// This is going to haunt me for a while.
 	var b bytes.Buffer
-	if err := markdown.New(markdown.WithRendererOptions(htmlrenderer.WithUnsafe())).Convert(input, &b); err != nil {
+	if err := markdownConverter.Convert(input, &b); err != nil {
 		return err
 	}
 	md := []byte(html.UnescapeString(b.String()))
@@ -512,7 +562,7 @@ func (gen *Generator) Markdown(e *goquery.Selection, doc *goquery.Document, data
 			return err
 		}
 		var b bytes.Buffer
-		if err := markdown.New(markdown.WithRendererOptions(htmlrenderer.WithUnsafe())).Convert(mdInput, &b); err != nil {
+		if err := markdownConverter.Convert(mdInput, &b); err != nil {
 			return err
 		}
 		mdDoc, err := gen.parseAndReplace(b, data)

--- a/generate.go
+++ b/generate.go
@@ -184,7 +184,19 @@ func (gen *Generator) Generate(path string, data *ZasData) (err error) {
 	return
 }
 
+// maxEmbedDepth bounds how many levels of <embed> an entry file may nest.
+// Markdown and HTML embed handlers call back into parseAndReplace for
+// whatever they embed, so a file that embeds itself (directly, or through a
+// cycle of mutually-embedding files) would otherwise recurse until the
+// goroutine's stack is exhausted.
+const maxEmbedDepth = 20
+
 func (gen *Generator) parseAndReplace(processed bytes.Buffer, data *ZasData) (doc *goquery.Document, err error) {
+	if data.embedDepth >= maxEmbedDepth {
+		return nil, fmt.Errorf("embed nesting deeper than %d levels; check for a self- or mutually-embedding file", maxEmbedDepth)
+	}
+	data.embedDepth++
+	defer func() { data.embedDepth-- }()
 	// Here we manipulate its result.
 	doc, err = goquery.NewDocumentFromReader(&processed)
 	if err != nil {

--- a/generate_run_test.go
+++ b/generate_run_test.go
@@ -1,0 +1,71 @@
+package zas
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Exercises the full generation pipeline - Run, walk, renderMarkdown,
+// render, parseAndReplace, Generate - against a minimal real site on disk,
+// composing every fix in this series. index.md is the exact reproducer from
+// https://github.com/darccio/zas/issues/16.
+
+func TestGenerateFullSite(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	must := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	must(os.MkdirAll(ZAS_DIR, 0o755))
+	must(os.WriteFile(ZAS_CONF_FILE, []byte(`zas:
+  layout: `+ZAS_DIR+`/layout.html
+  deploy: `+ZAS_DIR+`/deploy
+site:
+  baseurl: http://example.com
+  language: en
+mimetypes:
+  text/markdown: markdown
+  text/plain: plain
+  text/html: html
+`), 0o644))
+	must(os.WriteFile(filepath.Join(ZAS_DIR, "layout.html"), []byte(
+		`<html><head><title>{{.Title}}</title></head>`+
+			`<body><h2 id="i18n">{{.E "greeting" "World"}}</h2>`+
+			`<main class="inside">{{.Body}}</main></body></html>`), 0o644))
+	must(os.WriteFile(ZAS_I18N_FILE, []byte("greeting:\n  en: \"Hello %s\"\n"), 0o644))
+	must(os.WriteFile("index.md", []byte("<div>\nHello world!\n</div>\n"), 0o644))
+	must(os.WriteFile("about.md", []byte("<!-- title: Overridden -->\n\n# Ignored\n\nBody text.\n"), 0o644))
+
+	gen := &Generator{Full: true}
+	if err := gen.Run(); err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
+	}
+
+	index, err := os.ReadFile(filepath.Join(ZAS_DIR, "deploy", "index.html"))
+	must(err)
+	got := string(index)
+	for _, want := range []string{"<div>", "Hello world!", "</div>", "Hello World"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("index.html = %q, want it to contain %q", got, want)
+		}
+	}
+	for _, unwanted := range []string{"raw HTML omitted", "<p></p>"} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("index.html = %q, want it to not contain %q", got, unwanted)
+		}
+	}
+	if n := strings.Count(got, "<body"); n != 1 {
+		t.Fatalf("index.html has %d <body> tags, want 1: %q", n, got)
+	}
+
+	about, err := os.ReadFile(filepath.Join(ZAS_DIR, "deploy", "about.html"))
+	must(err)
+	if want := "<title>Overridden</title>"; !strings.Contains(string(about), want) {
+		t.Fatalf("about.html = %q, want it to contain %q", about, want)
+	}
+}

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -1,0 +1,96 @@
+package zas
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// Goldmark's default renderer replaces raw HTML blocks and inline HTML with
+// an "raw HTML omitted" placeholder. That silently destroyed the per-page
+// config comment and any <embed> tag written directly in a .md source, and
+// dropped any other HTML an author wrote by hand - including the exact
+// input from https://github.com/darccio/zas/issues/16, where a bare <div>
+// around a Markdown page's content was expected to survive untouched.
+//
+// markdownConverter fixes this by overriding only the raw-HTML node kinds,
+// rather than enabling goldmark's blanket "unsafe" mode - which would also
+// disable link/image destination sanitization against javascript:/data:
+// URLs. See TestMarkdownSanitizesDangerousLinkURL and
+// TestMarkdownSanitizesDangerousImageURL below.
+
+func convertMarkdown(t *testing.T, src string) string {
+	t.Helper()
+	var b bytes.Buffer
+	if err := markdownConverter.Convert([]byte(src), &b); err != nil {
+		t.Fatal(err)
+	}
+	return b.String()
+}
+
+func TestMarkdownKeepsRawHTMLBlock(t *testing.T) {
+	out := convertMarkdown(t, "<div>\nHello world!\n</div>\n")
+	if strings.Contains(out, "raw HTML omitted") {
+		t.Fatalf("output = %q, raw HTML was replaced with a placeholder", out)
+	}
+	for _, want := range []string{"<div>", "Hello world!", "</div>"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output = %q, want it to contain %q", out, want)
+		}
+	}
+}
+
+func TestMarkdownDoesNotWrapBlockHTMLInParagraph(t *testing.T) {
+	// The issue #16 reproducer: a bare <div> is a CommonMark HTML block, not
+	// paragraph content, so it must never end up wrapped in <p></p>.
+	out := convertMarkdown(t, "<div>\nHello world!\n</div>\n")
+	if strings.Contains(out, "<p>") {
+		t.Fatalf("output = %q, want no <p> wrapping the raw HTML block", out)
+	}
+}
+
+func TestMarkdownKeepsLeadingConfigComment(t *testing.T) {
+	out := convertMarkdown(t, "<!-- title: X -->\n\nHello\n")
+	if !strings.Contains(out, "<!-- title: X -->") {
+		t.Fatalf("output = %q, want the leading comment preserved", out)
+	}
+}
+
+func TestMarkdownKeepsEmbedTag(t *testing.T) {
+	// A blank line before the tag is required: an HTML block of this kind
+	// cannot interrupt an open paragraph under CommonMark's rules.
+	out := convertMarkdown(t, "Text before.\n\n<embed src=\"nav.md\" type=\"text/markdown\" />\n")
+	if strings.Contains(out, "raw HTML omitted") {
+		t.Fatalf("output = %q, embed tag was replaced with a placeholder", out)
+	}
+	if !strings.Contains(out, `<embed src="nav.md" type="text/markdown"`) {
+		t.Fatalf("output = %q, want the embed tag preserved verbatim", out)
+	}
+}
+
+func TestMarkdownEscapesEntitiesInFencedCode(t *testing.T) {
+	out := convertMarkdown(t, "```\n&lt;script&gt;\n```\n")
+	if !strings.Contains(out, "&amp;lt;script&amp;gt;") {
+		t.Fatalf("output = %q, want literal entities in code left escaped, not interpreted", out)
+	}
+}
+
+func TestMarkdownSanitizesDangerousLinkURL(t *testing.T) {
+	out := convertMarkdown(t, "[x](javascript:alert(1))\n")
+	if strings.Contains(out, "javascript:") {
+		t.Fatalf("output = %q, want the javascript: destination stripped, not just raw HTML passed through", out)
+	}
+	if !strings.Contains(out, `href=""`) {
+		t.Fatalf("output = %q, want an empty href for a sanitized destination", out)
+	}
+}
+
+func TestMarkdownSanitizesDangerousImageURL(t *testing.T) {
+	out := convertMarkdown(t, "![x](data:text/html;base64,x)\n")
+	if strings.Contains(out, "data:text/html") {
+		t.Fatalf("output = %q, want the data: destination stripped", out)
+	}
+	if !strings.Contains(out, `src=""`) {
+		t.Fatalf("output = %q, want an empty src for a sanitized destination", out)
+	}
+}


### PR DESCRIPTION
Stacks on #25 - this builds directly on that fix rather than duplicating it. Since #25's branch lives on a fork and was opened against an old base commit, the `pr25-on-master` branch this PR targets is #25's change cherry-picked onto current `master` (clean, no conflicts) so it can serve as a same-repo stacking point; once #25 merges, this PR's diff collapses to just what's described below.

## Summary

Three commits address the review feedback on #25 directly:

- **Raw HTML passthrough was scoped down to stop disabling URL sanitization.** `WithUnsafe()` gates goldmark's raw-HTML rendering and its `javascript:`/`data:`/etc. link and image sanitization behind the same flag, so turning one on turned the other off too. Replaced with a renderer that overrides only the two raw-HTML node kinds, leaving link/image sanitization on its default behavior. This also hoists the Markdown converter to a package-level, built-once value instead of constructing a new parser and renderer per file.
- **Source `<body>` attributes are preserved when merging into the layout.** Extracting the source page's inner HTML instead of its whole `<body>` element (the fix for the double-nested-`<body>` problem) had the side effect of silently dropping any attributes on the source's own `<body>` tag. Now they're captured and merged onto the layout's `<body>` - the layout's own attribute still wins on a collision, matching the old (accidental) merge behavior.

Three more commits carry over independently useful fixes:

- **Embed nesting is now capped.** An `<embed>` tag embedding itself (or a cycle of files embedding each other) recurses unboundedly now that raw HTML - including `<embed>` - survives conversion. Capped at 20 levels with a descriptive error instead of a stack overflow.
- **The dead paragraph-cleanup helper is fixed.** It read a tag name instead of a node's children to decide whether a `<p>` was empty, so its removal branch could never run - flagged independently in the review on #25. Fixed to remove exactly the empty `<p>` elements HTML5 parser error recovery leaves behind when a block element sits inline inside a Markdown paragraph.
- **An end-to-end regression test**, covering the full generation pipeline against a small site on disk, including the exact reproducer from #16.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -race` (54 tests, all passing)
- [x] `gofmt -l` on all changed Go files
- [x] Manually built the binary: confirmed `javascript:` links are still stripped (`href=""`) with the scoped renderer, where broad `WithUnsafe()` lets them through; confirmed a source page's `<body id="..." data-x="...">` attributes now survive into the deployed output
- [x] Each new fix has a regression test that fails against the pre-fix code (verified manually)
