### PR TITLE
refactor: run templates before Markdown conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ Keep in mind that any file will be treated as a Go text template before any furt
 * `{{.Resolve id}}`: indirect access to site, directory and page config. It works with simple keys (no paths), checking for them in page, directory and site config (as `/site/<id>`), in this order.
 * `{{.Language}}`: file current language, if defined in the first comment (as YAML property `language`). By default, `/site/language` value.
 
+For Markdown files, templates run against the `.md` source itself, before Markdown conversion. This means a template action's output - including a translated string from `{{.E}}` or `{{.H}}` - is Markdown source too: characters like `*`, `_`, `#`, or a leading `-`/digit-`.` are interpreted as formatting once conversion runs, and a blank line produced by a control action (`{{if}}`, `{{range}}`, ...) can split a paragraph, list, or table the same as a literal blank line would. Use `{{-` / `-}}` to trim stray whitespace from control actions when that matters.
+
 ### What about layout.html?
 
 It is plain HTML. No frills. Just add a placeholder `{{.Body}}` in your template.

--- a/body_attrs_test.go
+++ b/body_attrs_test.go
@@ -33,7 +33,7 @@ func TestRenderPreservesSourceBodyAttributes(t *testing.T) {
 	gen.Layout = layout
 
 	src := `<body id="special" data-x="1" class="source">content</body>`
-	if err := gen.render("page.html", []byte(src)); err != nil {
+	if err := gen.render("page.html", []byte(src), nil); err != nil {
 		t.Fatalf("render() error = %v, want nil", err)
 	}
 
@@ -67,7 +67,7 @@ func TestRenderWithoutSourceBodyAttributesLeavesLayoutUnchanged(t *testing.T) {
 	}
 	gen.Layout = layout
 
-	if err := gen.render("page.html", []byte(`<body>content</body>`)); err != nil {
+	if err := gen.render("page.html", []byte(`<body>content</body>`), nil); err != nil {
 		t.Fatalf("render() error = %v, want nil", err)
 	}
 

--- a/generate.go
+++ b/generate.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"html"
 	thtml "html/template"
 	"io"
 	"os"
@@ -156,7 +155,7 @@ func (gen *Generator) Generate(path string, data *ZasData) (err error) {
 	if err = gen.Layout.Execute(&processed, data); err != nil {
 		return
 	}
-	doc, err := gen.parseAndReplace(processed, data)
+	doc, err := gen.parseAndReplace(&processed, data)
 	if err != nil {
 		return
 	}
@@ -191,14 +190,14 @@ func (gen *Generator) Generate(path string, data *ZasData) (err error) {
 // goroutine's stack is exhausted.
 const maxEmbedDepth = 20
 
-func (gen *Generator) parseAndReplace(processed bytes.Buffer, data *ZasData) (doc *goquery.Document, err error) {
+func (gen *Generator) parseAndReplace(r io.Reader, data *ZasData) (doc *goquery.Document, err error) {
 	if data.embedDepth >= maxEmbedDepth {
 		return nil, fmt.Errorf("embed nesting deeper than %d levels; check for a self- or mutually-embedding file", maxEmbedDepth)
 	}
 	data.embedDepth++
 	defer func() { data.embedDepth-- }()
 	// Here we manipulate its result.
-	doc, err = goquery.NewDocumentFromReader(&processed)
+	doc, err = goquery.NewDocumentFromReader(r)
 	if err != nil {
 		return
 	}
@@ -393,13 +392,7 @@ func (gen *Generator) renderMarkdown(path string) (err error) {
 	if err != nil {
 		return
 	}
-	// This is going to haunt me for a while.
-	var b bytes.Buffer
-	if err := markdownConverter.Convert(input, &b); err != nil {
-		return err
-	}
-	md := []byte(html.UnescapeString(b.String()))
-	return gen.render(path, md)
+	return gen.render(path, input, markdownToHTML)
 }
 
 /*
@@ -410,7 +403,20 @@ func (gen *Generator) renderHTML(path string) (err error) {
 	if err != nil {
 		return
 	}
-	return gen.render(path, input)
+	return gen.render(path, input, nil)
+}
+
+/*
+ * Converts Markdown source to HTML. Used as render's convert step, so it
+ * runs after the Go template pass instead of before - template actions are
+ * written in the author's own syntax, not in goldmark's escaped output.
+ */
+func markdownToHTML(src []byte) ([]byte, error) {
+	var b bytes.Buffer
+	if err := markdownConverter.Convert(src, &b); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 /*
@@ -462,11 +468,13 @@ func (gen *Generator) setCachedDirConfig(path string, config ConfigSection) {
 }
 
 /*
- * Generic render function. It expects input to be a valid HTML document.
- * Input can be a valid Go template.
+ * Generic render function. input is executed as a Go template first, then -
+ * if convert is non-nil - converted to HTML (e.g. from Markdown). Templates
+ * therefore run against the author's own source syntax rather than against
+ * already-converted HTML.
  */
-func (gen *Generator) render(path string, input []byte) (err error) {
-	template, err := ttext.New("current").Parse(string(input))
+func (gen *Generator) render(path string, input []byte, convert func([]byte) ([]byte, error)) (err error) {
+	template, err := ttext.New(path).Parse(string(input))
 	if err != nil {
 		return
 	}
@@ -480,7 +488,13 @@ func (gen *Generator) render(path string, input []byte) (err error) {
 	if err = template.Execute(&processed, &data); err != nil {
 		return
 	}
-	doc, err := gen.parseAndReplace(processed, &data)
+	content := processed.Bytes()
+	if convert != nil {
+		if content, err = convert(content); err != nil {
+			return
+		}
+	}
+	doc, err := gen.parseAndReplace(bytes.NewReader(content), &data)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -589,7 +603,7 @@ func (gen *Generator) Markdown(e *goquery.Selection, doc *goquery.Document, data
 		if err := markdownConverter.Convert(mdInput, &b); err != nil {
 			return err
 		}
-		mdDoc, err := gen.parseAndReplace(b, data)
+		mdDoc, err := gen.parseAndReplace(&b, data)
 		if err != nil {
 			return err
 		}
@@ -633,7 +647,7 @@ func (gen *Generator) Html(e *goquery.Selection, doc *goquery.Document, data *Za
 			return err
 		}
 		var htmlDoc *goquery.Document
-		htmlDoc, err = gen.parseAndReplace(*bytes.NewBuffer(input), data)
+		htmlDoc, err = gen.parseAndReplace(bytes.NewReader(input), data)
 		if err != nil {
 			return
 		}

--- a/page_data_test.go
+++ b/page_data_test.go
@@ -52,7 +52,7 @@ func TestRenderPageBodyCanCallPointerReceiverMethod(t *testing.T) {
 	}
 	gen.Layout = layout
 
-	if err := gen.render("page.html", []byte(`<body>{{.URL}}</body>`)); err != nil {
+	if err := gen.render("page.html", []byte(`<body>{{.URL}}</body>`), nil); err != nil {
 		t.Fatalf("render() error = %v, want nil", err)
 	}
 

--- a/render_order_test.go
+++ b/render_order_test.go
@@ -1,0 +1,51 @@
+package zas
+
+import (
+	thtml "html/template"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/melvinmt/gt"
+)
+
+// The Go template pass must run over a Markdown page's *source*, before
+// Markdown conversion - not over the already-converted HTML. Otherwise
+// Markdown syntax coming out of a template action (e.g. a translated
+// string) reaches the reader as literal text instead of being rendered,
+// since Goldmark never gets a chance to see it.
+
+func TestRenderMarkdownExecutesTemplateBeforeConversion(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.MkdirAll("deploy", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gen := &Generator{
+		Config: ConfigSection{
+			"zas":  ConfigSection{"deploy": "deploy"},
+			"site": ConfigSection{"language": "en"},
+		},
+		I18n: &gt.Build{
+			Index:  gt.Strings{"shout": {"en": "**important**"}},
+			Origin: "en",
+		},
+	}
+	layout, err := thtml.New("layout").Funcs(helpers).Parse(`{{.Body}}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gen.Layout = layout
+
+	if err := gen.render("page.md", []byte(`{{.E "shout"}} today`), markdownToHTML); err != nil {
+		t.Fatalf("render() error = %v, want nil", err)
+	}
+
+	out, err := os.ReadFile(filepath.Join("deploy", "page.html"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "<strong>important</strong>"; !strings.Contains(string(out), want) {
+		t.Fatalf("deployed output = %q, want the translated text converted as Markdown (%q)", out, want)
+	}
+}


### PR DESCRIPTION
Stacks on #31 (which stacks on #25) - rebuilt on top of #31's restructure, unchanged in substance.

## Summary

Templates used to execute *after* Markdown conversion, on the already-converted HTML rather than the page's own source. That only worked because the entire converted output was entity-unescaped first as a workaround (there's an old code comment - "This is going to haunt me for a while." - right where it happened), and that workaround had a real cost: it also unescaped anything inside a `<code>`/`<pre>` block, turning escaped entities live and destroying literal text that was supposed to stay literal. Root cause was the ordering itself.

This flips it: templates now run against a page's raw source, and Markdown conversion (when applicable) happens on the template's output. The unescape workaround is deleted entirely, so code blocks are no longer touched by it.

**This changes observable behavior for Markdown pages**, worth reviewer attention:
- A template action's output is now Markdown source. Formatting characters coming out of a translated string (or any other template output) are interpreted instead of staying literal - e.g. a translation containing `**bold**` now renders as actual bold text.
- A blank line produced by a control action (`{{if}}`, `{{range}}`, ...) can now split a paragraph, list, or table, the same as a literal blank line would.
- Template parse errors now cite the author's own source file instead of an internal placeholder name.

Both behavior changes are documented in the README next to the rest of the template field reference.

Small mechanical cleanup riding along: `parseAndReplace` now takes an `io.Reader` instead of a `bytes.Buffer` by value, which removes a buffer-copy workaround at one of its three call sites.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -race` (55 tests, all passing)
- [x] `gofmt -l` on all changed Go files
- [x] Manually built the binary and confirmed everything composes: the issue #16 fix, template-before-Markdown ordering (a translated `**bold**` string renders as real bold), URL sanitization (`javascript:` still stripped), source `<body>` attribute preservation, and code-block entity escaping all work together on one page
- [x] New regression test proves the ordering directly
