### PR TITLE
fix(markdown): render code blocks correctly instead of unescaping them

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,9 @@ drwxr-xr-x  7 Dario  staff  238 30 mar 16:19 ..
 
 All .md files will be converted to HTML and copied in `.zas/deploy` using `.zas/layout.html` as layout and copying any other files and their structure. The former is also true for HTML files.
 
-Keep in mind that any file will be treated as a Go text template before any further processing. You have access to these fields and methods from anywhere:
+Fenced and indented code blocks are rendered as `<pre><code>`, with a fence's info string (e.g. ` ```go `) becoming a `class="language-go"` on the `<code>` element. There is no syntax highlighting built in; style or highlight that class yourself if you want one.
+
+Keep in mind that any file will be treated as a Go text template before any further processing, **including the contents of code blocks**: `{{...}}` inside a fenced or indented block is executed as a template, not shown literally. To display literal double braces, write `{{"{{"}}`. You have access to these fields and methods from anywhere:
 
 * `{{.Body}}`: the file itself in HTML.
 * `{{.Title}}`: autodetected title (first H1 header in file), overridden by `title` property in page's config.

--- a/codeblock_test.go
+++ b/codeblock_test.go
@@ -1,0 +1,85 @@
+package zas
+
+import (
+	"strings"
+	"testing"
+)
+
+// renderMarkdown used to run goldmark's converter output through
+// html.UnescapeString before handing it to the HTML5 parser in
+// parseAndReplace. Goldmark escapes code block contents on the way out, so
+// that unescape turned HTML entities inside a fenced or indented code block
+// back into raw markup bytes right before they were re-parsed as HTML -
+// corrupting <, >, and & in code samples, and turning a literal <script>
+// tag typed inside a code fence into a live, executing script. These tests
+// drive the full Generator.Run pipeline (not just markdownConverter, which
+// cannot observe this bug) against testdata/site/codeblocks.md.
+
+func TestGenerateEscapesHTMLInFencedCodeBlock(t *testing.T) {
+	newTestSite(t, "site")
+	if err := generate(t); err != nil {
+		t.Fatalf("generate() error = %v, want nil", err)
+	}
+	out := readDeploy(t, "codeblocks.html")
+	if !strings.Contains(out, "&lt;b&gt;hi&lt;/b&gt;") {
+		t.Fatalf("codeblocks.html = %q, want the fenced <b>hi</b> sample left escaped", out)
+	}
+	if strings.Contains(out, "<b>hi</b>") {
+		t.Fatalf("codeblocks.html = %q, want no real <b> element from the code sample", out)
+	}
+}
+
+func TestGenerateDoesNotExecuteScriptInFencedCodeBlock(t *testing.T) {
+	newTestSite(t, "site")
+	if err := generate(t); err != nil {
+		t.Fatalf("generate() error = %v, want nil", err)
+	}
+	out := readDeploy(t, "codeblocks.html")
+	if !strings.Contains(out, "&lt;script&gt;alert(1)&lt;/script&gt;") {
+		t.Fatalf("codeblocks.html = %q, want the fenced <script> sample left escaped", out)
+	}
+	if strings.Contains(out, "<script>alert(1)</script>") {
+		t.Fatalf("codeblocks.html = %q, want no live <script> element from the code sample", out)
+	}
+}
+
+func TestGenerateKeepsDoubleEscapedEntitiesInCodeBlock(t *testing.T) {
+	newTestSite(t, "site")
+	if err := generate(t); err != nil {
+		t.Fatalf("generate() error = %v, want nil", err)
+	}
+	out := readDeploy(t, "codeblocks.html")
+	want := `<pre><code class="language-text">&amp;lt;script&amp;gt;`
+	if !strings.Contains(out, want) {
+		t.Fatalf("codeblocks.html = %q, want it to contain %q (literal &lt;script&gt; typed in source keeping its full escaping)", out, want)
+	}
+	degraded := `<pre><code class="language-text">&lt;script&gt;`
+	if strings.Contains(out, degraded) {
+		t.Fatalf("codeblocks.html = %q, the language-text block lost a level of escaping (want &amp;lt;..&amp;gt;, got &lt;..&gt;)", out)
+	}
+}
+
+func TestGenerateEscapesHTMLInIndentedCodeBlock(t *testing.T) {
+	newTestSite(t, "site")
+	if err := generate(t); err != nil {
+		t.Fatalf("generate() error = %v, want nil", err)
+	}
+	out := readDeploy(t, "codeblocks.html")
+	if !strings.Contains(out, "&lt;b&gt;indented&lt;/b&gt;") {
+		t.Fatalf("codeblocks.html = %q, want the indented <b>indented</b> sample left escaped", out)
+	}
+	if strings.Contains(out, "<b>indented</b>") {
+		t.Fatalf("codeblocks.html = %q, want no real <b> element from the indented sample", out)
+	}
+}
+
+func TestGenerateFencedCodeBlockGetsLanguageClass(t *testing.T) {
+	newTestSite(t, "site")
+	if err := generate(t); err != nil {
+		t.Fatalf("generate() error = %v, want nil", err)
+	}
+	out := readDeploy(t, "codeblocks.html")
+	if !strings.Contains(out, `<pre><code class="language-html">`) {
+		t.Fatalf("codeblocks.html = %q, want a fenced code block with a language-html class", out)
+	}
+}

--- a/generate.go
+++ b/generate.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"html"
 	thtml "html/template"
 	"io"
 	"os"
@@ -393,13 +392,17 @@ func (gen *Generator) renderMarkdown(path string) (err error) {
 	if err != nil {
 		return
 	}
-	// This is going to haunt me for a while.
 	var b bytes.Buffer
 	if err := markdownConverter.Convert(input, &b); err != nil {
 		return err
 	}
-	md := []byte(html.UnescapeString(b.String()))
-	return gen.render(path, md)
+	// Do not unescape the converter's output here: goldmark escapes code
+	// block contents (and rawHTMLRenderer above already passes raw HTML
+	// through verbatim), so unescaping would let HTML entities inside a
+	// fenced or indented code block turn back into real elements once
+	// parseAndReplace re-parses this as HTML - including a <script> tag
+	// becoming a live, executing script.
+	return gen.render(path, b.Bytes())
 }
 
 /*

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -94,3 +94,17 @@ func TestMarkdownSanitizesDangerousImageURL(t *testing.T) {
 		t.Fatalf("output = %q, want an empty src for a sanitized destination", out)
 	}
 }
+
+func TestMarkdownFencedCodeBlockGetsLanguageClass(t *testing.T) {
+	out := convertMarkdown(t, "```go\nfmt.Println(1)\n```\n")
+	if !strings.Contains(out, `<pre><code class="language-go">`) {
+		t.Fatalf("output = %q, want a fenced code block with a language-go class", out)
+	}
+}
+
+func TestMarkdownIndentedCodeBlockRenders(t *testing.T) {
+	out := convertMarkdown(t, "    fmt.Println(1)\n")
+	if !strings.Contains(out, "<pre><code>") {
+		t.Fatalf("output = %q, want an indented code block wrapped in <pre><code>", out)
+	}
+}

--- a/testdata/site/codeblocks.md
+++ b/testdata/site/codeblocks.md
@@ -1,0 +1,15 @@
+# Code blocks
+
+```html
+<b>hi</b>
+```
+
+```html
+<script>alert(1)</script>
+```
+
+```text
+&lt;script&gt;
+```
+
+    <b>indented</b>


### PR DESCRIPTION
## Summary

- `renderMarkdown` ran goldmark's converter output through `html.UnescapeString` before handing it to the HTML5 parser. Goldmark escapes code block contents on the way out, so the unescape reversed that protection right before parsing: `<`, `>`, and `&` inside a fenced or indented code block turned back into raw markup bytes and were parsed as real elements. A `<script>` tag typed inside a code fence became a live, executing script.
- The unescape was vestigial, left over from the blackfriday-based renderer where it was a crude way to let hand-written HTML (leading config comment, `<embed>` tags) survive conversion. `rawHTMLRenderer` now does that job properly, and the `<embed type="text/markdown">` embed path never had the unescape — so top-level and embedded Markdown disagreed on escaping until now.
- No goldmark config changes: fenced/indented code blocks already rendered as `<pre><code>`, with a fence's info string becoming `class="language-x"`. No syntax highlighting is added (no new dependency).

## Why the fix is safe

Verified against `x/net/html`'s renderer: `<pre>`/`<code>` are not in the literal-text-node set (`script`, `style`, `iframe`, etc.), so their text content is escaped on serialization, and the parser's leading-newline handling for `<pre>` is preserved across the two parse/serialize round-trips the pipeline already does.

## Test plan

- [x] `go build ./...` / `go vet ./...`
- [x] `go test -race ./...` — full suite green, including the existing raw-HTML passthrough and `javascript:`/`data:` URL sanitization tests
- [x] New `codeblock_test.go` drives the full `Generator.Run` pipeline (existing markdown tests only hit the converter directly and couldn't observe this bug) against a new `testdata/site/codeblocks.md` fixture, asserting escaped output for a plain HTML sample, a literal `<script>` sample, a double-escaped-entity sample, and an indented code block
- [x] Confirmed the new tests fail without the fix — reverting it reproduces a live `<script>alert(1)</script>` element in the deployed HTML
- [x] `markdown_test.go` gains converter-level checks for the `language-*` class and indented-block rendering
- [x] `README.md` documents code block rendering and the pre-existing (unchanged) behavior that `{{...}}` inside a code block still runs as a Go template