### PR TITLE
fix(generate): don't abort generate when reaping a removed directory 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ coverage.out
 # Local test site output
 .zas/deploy/
 
+# Local working notes
+/docs/
+
 #####=== Vim ===#####
 [._]*.s[a-w][a-z]
 [._]s[a-w][a-z]

--- a/generate.go
+++ b/generate.go
@@ -121,6 +121,10 @@ type Generator struct {
 	// Guards errs, which collects per-file render errors from renderAsync goroutines.
 	mu   sync.Mutex
 	errs []error
+
+	// reapedDirs holds deploy paths reaper has RemoveAll'd during the
+	// current reap walk. The reap walk is single-threaded, so no mutex.
+	reapedDirs map[string]struct{}
 }
 
 /*
@@ -334,6 +338,14 @@ func (gen *Generator) renderAsync(path string) {
  */
 func (gen *Generator) reaper(path string, _ os.FileInfo, err error) (ierr error) {
 	if err != nil {
+		// filepath.Walk lists a directory's children before invoking this
+		// callback for the directory itself, so RemoveAll below leaves Walk
+		// holding a stale child list for path's parent; the lstat it then
+		// retries on each child surfaces here as a not-exist error we
+		// already caused by reaping the parent.
+		if _, ok := gen.reapedDirs[filepath.Dir(path)]; ok && os.IsNotExist(err) {
+			return nil
+		}
 		return err
 	}
 	sourcePath := strings.Replace(path, gen.GetDeployPath(), ".", 1)
@@ -355,6 +367,11 @@ func (gen *Generator) reaper(path string, _ os.FileInfo, err error) (ierr error)
 			}
 			if rmErr := os.RemoveAll(path); rmErr != nil {
 				gen.recordErr(rmErr)
+			} else {
+				if gen.reapedDirs == nil {
+					gen.reapedDirs = make(map[string]struct{})
+				}
+				gen.reapedDirs[path] = struct{}{}
 			}
 		}
 	} else {

--- a/generate_e2e_test.go
+++ b/generate_e2e_test.go
@@ -117,6 +117,34 @@ func TestGenerateFullRebuilds(t *testing.T) {
 	assertDeployHas(t, "index.html")
 }
 
+func TestGenerateIncrementalReapsRemovedDirectory(t *testing.T) {
+	newTestSite(t, "site")
+	if err := os.MkdirAll("sect", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join("sect", "index.md"), []byte("# Sect\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join("sect", "more.md"), []byte("# More\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := generate(t, fullGen); err != nil {
+		t.Fatalf("first generate() error = %v, want nil", err)
+	}
+	assertDeployHas(t, filepath.Join("sect", "index.html"))
+	assertDeployHas(t, filepath.Join("sect", "more.html"))
+
+	if err := os.RemoveAll("sect"); err != nil {
+		t.Fatal(err)
+	}
+	if err := generate(t); err != nil {
+		t.Fatalf("incremental generate() after removing a non-empty source directory: error = %v, want nil", err)
+	}
+	assertDeployMissing(t, "sect")
+	assertDeployMissing(t, filepath.Join("sect", "index.html"))
+	assertDeployMissing(t, filepath.Join("sect", "more.html"))
+}
+
 func TestGenerateFailsOutsideRepository(t *testing.T) {
 	t.Chdir(t.TempDir())
 	err := generate(t)


### PR DESCRIPTION
Incremental generate walks the deploy tree with reaper as the
filepath.Walk callback, deleting deploy files and directories whose
source no longer exists. When reaper RemoveAll's a whole directory,
it does so mid-walk: Walk had already read that directory's child
names before invoking the callback for the directory itself, so its
next step - lstat-ing each cached child - now fails because reaper
just deleted them. Walk feeds that failure back into reaper as a
non-nil err on each child path.

A previous fix made reaper return any non-nil err immediately, which
is correct for genuine Walk errors (permission denied, disk errors),
but also turned this expected cascade into a hard failure: reaping a
source directory with at least one child aborted the entire reap walk,
and with it the whole generate run, even though nothing was actually
wrong.

Track the deploy paths reaper removes during the current reap walk,
and treat a not-exist error on a path whose parent is one of them as
already handled. Any other error, including not-exist errors for
unrelated paths, still propagates and aborts the run as before.