### PR TITLE
fix: .md/.html extension mapping to use suffix matching instead of substring replace

### DIFF
--- a/data.go
+++ b/data.go
@@ -166,9 +166,7 @@ func (zd *ZasData) IsHome() (bool, error) {
 // NewZasData builds a ZasData for the page at filepath.
 func NewZasData(filepath string, gen *Generator) (data ZasData) {
 	// Any path must finish in ".html".
-	if strings.HasSuffix(filepath, ".md") {
-		filepath = strings.ReplaceAll(filepath, ".md", ".html")
-	}
+	filepath = swapExtension(filepath, ".md", ".html")
 	data.Path = "/" + filepath
 	data.config = gen.Config
 	// Each ZasData gets its own gt.Build sharing the (read-only, post-init)

--- a/extension_test.go
+++ b/extension_test.go
@@ -1,0 +1,48 @@
+package zas
+
+import "testing"
+
+// E1: sourceIsNewer, NewZasData, and reaper each swapped .md/.html
+// extensions with strings.Replace/ReplaceAll on the whole path string,
+// instead of anchoring on the trailing extension - and disagreed with each
+// other on occurrence count while doing it. swapExtension is the single
+// helper all three now share.
+
+func TestSwapExtension(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		from string
+		to   string
+		want string
+	}{
+		{"simple extension swap", "page.md", ".md", ".html", "page.html"},
+		{"only the trailing occurrence is swapped", "a.md.md", ".md", ".html", "a.md.html"},
+		{"extension-like mid-name segment is untouched", "v1.mdx/page.md", ".md", ".html", "v1.mdx/page.html"},
+		{"trailing occurrence swapped even when an earlier one matches to", "x.html.md", ".md", ".html", "x.html.html"},
+		{"reverse swap also only touches the trailing occurrence", "x.html.html", ".html", ".md", "x.html.md"},
+		{"path without the suffix is returned unchanged", "style.css", ".md", ".html", "style.css"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := swapExtension(c.path, c.from, c.to); got != c.want {
+				t.Fatalf("swapExtension(%q, %q, %q) = %q, want %q", c.path, c.from, c.to, got, c.want)
+			}
+		})
+	}
+}
+
+// TestSwapExtensionRoundTrip pins the property that makes the three call
+// sites agree with each other: swapping .md -> .html and then .html -> .md
+// must return the original path.
+func TestSwapExtensionRoundTrip(t *testing.T) {
+	paths := []string{"page.md", "a.md.md", "v1.mdx/page.md", "x.html.md"}
+	for _, orig := range paths {
+		t.Run(orig, func(t *testing.T) {
+			html := swapExtension(orig, ".md", ".html")
+			if back := swapExtension(html, ".html", ".md"); back != orig {
+				t.Fatalf("round trip through %q = %q, want %q", html, back, orig)
+			}
+		})
+	}
+}

--- a/generate.go
+++ b/generate.go
@@ -146,6 +146,17 @@ func (gen *Generator) BuildDeployPath(path string) string {
 	return filepath.Join(gen.GetDeployPath(), path)
 }
 
+// swapExtension replaces path's trailing from extension with to. Paths not
+// ending in from are returned unchanged. Unlike strings.Replace/ReplaceAll,
+// this only ever touches the extension, never a from/to occurrence earlier
+// in path.
+func swapExtension(path, from, to string) string {
+	if !strings.HasSuffix(path, from) {
+		return path
+	}
+	return strings.TrimSuffix(path, from) + to
+}
+
 // Generate renders and writes the file at data.Path using the given
 // template context.
 func (gen *Generator) Generate(_ string, data *ZasData) (err error) {
@@ -354,7 +365,7 @@ func (gen *Generator) reaper(path string, _ os.FileInfo, err error) (ierr error)
 	if err != nil {
 		reap := true
 		if strings.HasSuffix(sourcePath, ".html") {
-			sourcePath = strings.Replace(sourcePath, ".html", ".md", 1)
+			sourcePath = swapExtension(sourcePath, ".html", ".md")
 			sourceNew, err := os.Open(sourcePath)
 			if err == nil {
 				_ = sourceNew.Close()
@@ -385,10 +396,7 @@ func (gen *Generator) sourceIsNewer(path string, sourceInfo os.FileInfo) bool {
 	if gen.Full {
 		return true
 	}
-	realpath := path
-	if strings.HasSuffix(path, ".md") {
-		realpath = strings.Replace(path, ".md", ".html", 1)
-	}
+	realpath := swapExtension(path, ".md", ".html")
 	destination, err := os.Open(gen.BuildDeployPath(realpath))
 	if err != nil {
 		return true

--- a/generate_e2e_test.go
+++ b/generate_e2e_test.go
@@ -145,6 +145,36 @@ func TestGenerateIncrementalReapsRemovedDirectory(t *testing.T) {
 	assertDeployMissing(t, filepath.Join("sect", "more.html"))
 }
 
+func TestGenerateHTMLDotMDSurvivesIncrementalRun(t *testing.T) {
+	newTestSite(t, "site")
+	if err := os.WriteFile("x.html.md", []byte("# X\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := generate(t, fullGen); err != nil {
+		t.Fatalf("first generate() error = %v, want nil", err)
+	}
+	assertDeployHas(t, "x.html.html")
+
+	if err := generate(t); err != nil {
+		t.Fatalf("incremental generate() error = %v, want nil", err)
+	}
+	assertDeployHas(t, "x.html.html")
+}
+
+func TestGenerateExtensionLikeDirectoryNotCorrupted(t *testing.T) {
+	newTestSite(t, "site")
+	if err := os.MkdirAll("v1.mdx", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join("v1.mdx", "page.md"), []byte("# Page\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := generate(t); err != nil {
+		t.Fatalf("generate() error = %v, want nil", err)
+	}
+	assertDeployHas(t, filepath.Join("v1.mdx", "page.html"))
+}
+
 func TestGenerateFailsOutsideRepository(t *testing.T) {
 	t.Chdir(t.TempDir())
 	err := generate(t)


### PR DESCRIPTION
## Summary

Three call sites map between a page's Markdown source path and its
HTML deploy path, and all three did it with `strings.Replace` /
`strings.ReplaceAll` on the whole path string instead of a
suffix-only operation:

- `sourceIsNewer` (staleness check for incremental builds) replaced
  only the first `.md` occurrence anywhere in the path.
- `NewZasData` (builds the deploy output path) replaced every `.md`
  occurrence anywhere in the path.
- `reaper` (deletes deploy files whose source vanished) replaced only
  the first `.html` occurrence anywhere in the path, in the reverse
  direction.

Because each was written independently, they didn't even agree with
each other on how many occurrences to replace, and none of them was
anchored to the trailing extension.

## Root cause and worst-case bug

A source file named `x.html.md` deploys to `x.html.html` (via
`NewZasData`'s all-occurrences replace, which happens to get this one
right by accident). On the very same incremental `zas generate` run,
`reaper`'s reverse check replaces the *first* `.html` occurrence in
the deploy path instead of the trailing one, turning `x.html.html`
into `x.md.html` - which doesn't exist as a source file. `reaper`
concludes the source is gone and deletes the deploy output that was
just generated in the same invocation. The build deletes its own
output.

Independently, any path where `.md`/`.html` appears mid-name rather
than as the true extension - for example a directory literally named
`v1.mdx/` - gets corrupted by the substring match even though `.mdx`
isn't `.md`. In the reproduction added here, this actually surfaces
as a hard render error (the deploy directory the corrupted path
points at was never created), not just a silently wrong output path.

## Fix

Added one shared helper, `swapExtension(path, from, to string) string`,
that uses `strings.HasSuffix` + `strings.TrimSuffix` + concatenation
to swap only a trailing extension, leaving the rest of the path
untouched. All three call sites now delegate to it, so they can't
independently drift out of agreement again.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -race` (74 tests, all passing)
- [x] Added `TestSwapExtension` and `TestSwapExtensionRoundTrip`
      (table-driven unit tests on the helper, covering a plain
      extension swap, an extension appearing twice in one name, an
      extension-shaped substring inside a longer segment like
      `.mdx`, and the round trip that keeps the three call sites in
      agreement).
- [x] Added `TestGenerateHTMLDotMDSurvivesIncrementalRun` and
      `TestGenerateExtensionLikeDirectoryNotCorrupted` end-to-end
      tests that drive the real `Generator.Run()` pipeline.
- [x] Verified both new end-to-end tests fail against the pre-fix
      code with the exact symptoms described above (deploy file
      missing after an incremental run; a hard "no such file or
      directory" render error), then pass after the fix.