### PR TITLE
fix(generate): stop walk from descending into skipped directories

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -310,7 +310,10 @@ func (gen *Generator) walk(path string, info os.FileInfo, err error) (ierr error
 		return err
 	}
 	if strings.HasPrefix(path, ".") || strings.HasPrefix(filepath.Base(path), ".") || strings.Contains(path, ZAS_DIR+"/") {
-		return
+		if path != "." && info.IsDir() {
+			return filepath.SkipDir
+		}
+		return nil
 	}
 	if info.IsDir() {
 		ierr = os.MkdirAll(gen.BuildDeployPath(path), os.FileMode(ZAS_DEFAULT_DIR_PERM))

--- a/generate_e2e_test.go
+++ b/generate_e2e_test.go
@@ -175,6 +175,26 @@ func TestGenerateExtensionLikeDirectoryNotCorrupted(t *testing.T) {
 	assertDeployHas(t, filepath.Join("v1.mdx", "page.html"))
 }
 
+func TestGenerateSkipsNestedHiddenDirectory(t *testing.T) {
+	newTestSite(t, "site")
+	if err := os.MkdirAll(filepath.Join("sect", ".hidden"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join("sect", "index.md"), []byte("# Sect\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join("sect", ".hidden", "page.md"), []byte("# Hidden\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := generate(t); err != nil {
+		t.Fatalf("generate() error = %v, want nil", err)
+	}
+	assertDeployHas(t, filepath.Join("sect", "index.html"))
+	assertDeployMissing(t, filepath.Join("sect", ".hidden"))
+	assertDeployMissing(t, filepath.Join("sect", ".hidden", "page.html"))
+	assertDeployMissing(t, ".zas")
+}
+
 func TestGenerateFailsOutsideRepository(t *testing.T) {
 	t.Chdir(t.TempDir())
 	err := generate(t)

--- a/walk_test.go
+++ b/walk_test.go
@@ -2,6 +2,8 @@ package zas
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -21,5 +23,56 @@ func TestReaperPropagatesErr(t *testing.T) {
 	wantErr := errors.New("permission denied")
 	if err := gen.reaper("noperm", nil, wantErr); !errors.Is(err, wantErr) {
 		t.Fatalf("reaper() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestWalkSkipsHiddenDirectory(t *testing.T) {
+	gen := &Generator{}
+	info, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join("sect", ".hidden")
+	if err := gen.walk(path, info, nil); !errors.Is(err, filepath.SkipDir) {
+		t.Fatalf("walk(%q) error = %v, want %v", path, err, filepath.SkipDir)
+	}
+}
+
+func TestWalkSkipsDeployDirectory(t *testing.T) {
+	gen := &Generator{}
+	info, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join("public", ZAS_DIR, "deploy")
+	if err := gen.walk(path, info, nil); !errors.Is(err, filepath.SkipDir) {
+		t.Fatalf("walk(%q) error = %v, want %v", path, err, filepath.SkipDir)
+	}
+}
+
+func TestWalkSkipsHiddenFileWithoutSkipDir(t *testing.T) {
+	gen := &Generator{}
+	file := filepath.Join(t.TempDir(), "x")
+	if err := os.WriteFile(file, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join("sect", ".gitignore")
+	if err := gen.walk(path, info, nil); err != nil {
+		t.Fatalf("walk(%q) error = %v, want nil", path, err)
+	}
+}
+
+func TestWalkDoesNotSkipDirAtRoot(t *testing.T) {
+	gen := &Generator{}
+	info, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := gen.walk(".", info, nil); err != nil {
+		t.Fatalf(`walk(".") error = %v, want nil`, err)
 	}
 }


### PR DESCRIPTION
## Summary
- `walk` (the `filepath.Walk` callback that drives source-tree traversal) matched hidden directories such as dotfiles and `.zas` by name but returned a bare `nil` instead of `filepath.SkipDir`, so `filepath.Walk` still recursed into their contents.
- A hidden directory nested inside a normal one (e.g. `sect/.hidden/page.md`) was never created in the deploy tree, but files inside it were still picked up and rendered, failing the whole build with a fatal error because their parent directory did not exist.
- The same gap meant `.git` and `.zas` were walked entry by entry on every run instead of being pruned at their root.
- Fix: return `filepath.SkipDir` when the skip condition matches a directory, with one exception — the walk root itself. `filepath.Walk` invokes the callback with `path "."` for the root, which also matches the existing dot-prefix check, so a naive `SkipDir` there aborts the entire walk before visiting anything; this was caught by running the full test suite, which failed across the board until the root case was excluded.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -race` (full suite, including new tests, all passing)
- [x] Manually reproduced the bug pre-fix (fatal error, exit 1) and confirmed the fix resolves it (exit 0, correct deploy tree) against a `sect/index.md` + `sect/.hidden/page.md` fixture
- [x] `strace`-verified `.git` is pruned at its root (opened once, never recursed into) rather than walked entry by entry
