### PR TITLE
docs: remove stray internal tracking-label reference from comment

### DIFF
--- a/extension_test.go
+++ b/extension_test.go
@@ -2,7 +2,7 @@ package zas
 
 import "testing"
 
-// E1: sourceIsNewer, NewZasData, and reaper each swapped .md/.html
+// sourceIsNewer, NewZasData, and reaper each used to swap .md/.html
 // extensions with strings.Replace/ReplaceAll on the whole path string,
 // instead of anchoring on the trailing extension - and disagreed with each
 // other on occurrence count while doing it. swapExtension is the single


### PR DESCRIPTION
## Summary
- A package comment in extension_test.go (added by a recent fix) led with an internal tracking-label prefix that shouldn't appear in tracked repository content.
- Removes the label while keeping the substantive explanation of why the swapExtension helper exists, adjusting verb tense since it now describes already-fixed past behavior rather than an open item.

## Test plan
- [x] go build ./...
- [x] go vet ./...
- [x] go test ./... -race