### PR TITLE
fix(generate): exclude configured deploy and layout paths from walk

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -309,7 +309,8 @@ func (gen *Generator) walk(path string, info os.FileInfo, err error) (ierr error
 	if err != nil {
 		return err
 	}
-	if strings.HasPrefix(path, ".") || strings.HasPrefix(filepath.Base(path), ".") || strings.Contains(path, ZAS_DIR+"/") {
+	if strings.HasPrefix(path, ".") || strings.HasPrefix(filepath.Base(path), ".") || strings.Contains(path, ZAS_DIR+"/") ||
+		path == gen.GetDeployPath() || path == gen.Config.GetZString("layout") {
 		if path != "." && info.IsDir() {
 			return filepath.SkipDir
 		}

--- a/generate_e2e_test.go
+++ b/generate_e2e_test.go
@@ -205,3 +205,87 @@ func TestGenerateFailsOutsideRepository(t *testing.T) {
 		t.Fatalf("generate() error = %v, want it to mention %q", err, "not a valid Zas repository")
 	}
 }
+
+// TestGenerateDeployPathOutsideZasDirNotWalkedAsSource is a regression test:
+// a deploy path outside .zas/ used to be walked as a source directory, so
+// each run re-rendered the previous run's own output through the layout
+// again and nested it one level deeper (public/public/..., compounding
+// every run).
+func TestGenerateDeployPathOutsideZasDirNotWalkedAsSource(t *testing.T) {
+	t.Chdir(t.TempDir())
+	saveGlobals(t)
+
+	must := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	must(os.MkdirAll(ZAS_DIR, 0o755))
+	must(os.WriteFile(ZAS_CONF_FILE, []byte(`zas:
+  layout: `+ZAS_DIR+`/layout.html
+  deploy: public
+site:
+  baseurl: http://example.com
+  language: en
+mimetypes:
+  text/markdown: markdown
+  text/plain: plain
+  text/html: html
+`), 0o644))
+	must(os.WriteFile(filepath.Join(ZAS_DIR, "layout.html"), []byte(
+		`<html><head><title>{{.Title}}</title></head><body>{{.Body}}</body></html>`), 0o644))
+	must(os.WriteFile("index.md", []byte("# Hello\n"), 0o644))
+
+	for range 3 {
+		if err := generate(t); err != nil {
+			t.Fatalf("generate() error = %v, want nil", err)
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join("public", "public")); !os.IsNotExist(err) {
+		t.Fatalf("public/public exists after 3 runs (stat err = %v), want it absent", err)
+	}
+	if _, err := os.Stat(filepath.Join("public", "index.html")); err != nil {
+		t.Fatalf("public/index.html missing: %v", err)
+	}
+}
+
+// TestGenerateLayoutPathOutsideZasDirNotPublishedAsPage is a regression
+// test: a layout file outside .zas/ used to be walked like any other page
+// and published under its own name in the deploy tree.
+func TestGenerateLayoutPathOutsideZasDirNotPublishedAsPage(t *testing.T) {
+	t.Chdir(t.TempDir())
+	saveGlobals(t)
+
+	must := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	must(os.MkdirAll(ZAS_DIR, 0o755))
+	must(os.WriteFile(ZAS_CONF_FILE, []byte(`zas:
+  layout: mylayout.html
+  deploy: `+ZAS_DIR+`/deploy
+site:
+  baseurl: http://example.com
+  language: en
+mimetypes:
+  text/markdown: markdown
+  text/plain: plain
+  text/html: html
+`), 0o644))
+	must(os.WriteFile("mylayout.html", []byte(
+		`<html><head><title>{{.Title}}</title></head><body>{{.Body}}</body></html>`), 0o644))
+	must(os.WriteFile("index.md", []byte("# Hello\n"), 0o644))
+	must(os.WriteFile("about.md", []byte("# About\n"), 0o644))
+
+	if err := generate(t); err != nil {
+		t.Fatalf("generate() error = %v, want nil", err)
+	}
+
+	assertDeployMissing(t, "mylayout.html")
+	assertDeployHas(t, "index.html")
+	assertDeployHas(t, "about.html")
+}

--- a/walk_test.go
+++ b/walk_test.go
@@ -50,6 +50,34 @@ func TestWalkSkipsDeployDirectory(t *testing.T) {
 	}
 }
 
+func TestWalkSkipsConfiguredDeployPathOutsideZasDir(t *testing.T) {
+	gen := &Generator{Config: ConfigSection{ZAS: ConfigSection{"deploy": "public"}}}
+	info, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := "public"
+	if err := gen.walk(path, info, nil); !errors.Is(err, filepath.SkipDir) {
+		t.Fatalf("walk(%q) error = %v, want %v", path, err, filepath.SkipDir)
+	}
+}
+
+func TestWalkSkipsConfiguredLayoutPathOutsideZasDir(t *testing.T) {
+	gen := &Generator{Config: ConfigSection{ZAS: ConfigSection{"layout": "mylayout.html"}}}
+	file := filepath.Join(t.TempDir(), "x")
+	if err := os.WriteFile(file, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := "mylayout.html"
+	if err := gen.walk(path, info, nil); err != nil {
+		t.Fatalf("walk(%q) error = %v, want nil", path, err)
+	}
+}
+
 func TestWalkSkipsHiddenFileWithoutSkipDir(t *testing.T) {
 	gen := &Generator{}
 	file := filepath.Join(t.TempDir(), "x")


### PR DESCRIPTION
## Summary
- `walk` only excluded the default `.zas/`-relative deploy and layout locations. A `deploy` or `layout` path configured outside `.zas` (e.g. `zas: {deploy: public}`) was walked like any other source directory/file.
- On incremental runs this let the deploy tree pick up its own prior output as a source file and re-render it through the layout, nesting one directory deeper every run (`public/public/index.html`, then `public/public/public/...`, indefinitely). A layout file living outside `.zas` was published as an ordinary page in the deploy tree.
- Extends the existing `.zas/` skip check in `walk` with an exact match against the configured deploy and layout paths, reusing the same `SkipDir`/`nil` branching already used for directories vs. files. The default, `.zas/`-relative configuration is unaffected — the `.zas/` check already prunes that directory before the new comparisons are reached.

## Test plan
- [x] Reproduced both bugs against the prior code: `deploy: public` run 3 times produced `public/public/` after run 2 and `public/public/public/` after run 3; `layout: mylayout.html` published `mylayout.html` itself into the deploy tree.
- [x] Added `TestWalkSkipsConfiguredDeployPathOutsideZasDir` / `TestWalkSkipsConfiguredLayoutPathOutsideZasDir` in `walk_test.go` exercising `walk` directly.
- [x] Added `TestGenerateDeployPathOutsideZasDirNotWalkedAsSource` (3 successive `generate` runs, asserts no `public/public`) and `TestGenerateLayoutPathOutsideZasDirNotPublishedAsPage` (asserts the layout is never deployed while ordinary pages still are) in `generate_e2e_test.go`.
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` clean.
- [x] `go test ./... -race` clean: 83 passing, 0 failing.