### PR TITLE
fix(generate): exclude .zas by path component instead of substring

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -302,6 +302,15 @@ func (gen *Generator) handleDeployPath(full bool) {
 	}
 }
 
+func pathHasComponent(path, component string) bool {
+	for _, part := range strings.Split(path, string(filepath.Separator)) {
+		if part == component {
+			return true
+		}
+	}
+	return false
+}
+
 /*
  * Real walking function. Handles all supported files and copy not supported ones in current deployment path.
  */
@@ -309,7 +318,7 @@ func (gen *Generator) walk(path string, info os.FileInfo, err error) (ierr error
 	if err != nil {
 		return err
 	}
-	if strings.HasPrefix(path, ".") || strings.HasPrefix(filepath.Base(path), ".") || strings.Contains(path, ZAS_DIR+"/") ||
+	if strings.HasPrefix(path, ".") || strings.HasPrefix(filepath.Base(path), ".") || pathHasComponent(path, ZAS_DIR) ||
 		path == gen.GetDeployPath() || path == gen.Config.GetZString("layout") {
 		if path != "." && info.IsDir() {
 			return filepath.SkipDir

--- a/generate_e2e_test.go
+++ b/generate_e2e_test.go
@@ -175,6 +175,25 @@ func TestGenerateExtensionLikeDirectoryNotCorrupted(t *testing.T) {
 	assertDeployHas(t, filepath.Join("v1.mdx", "page.html"))
 }
 
+// TestGenerateDirNameEndingInZasDirNotExcluded is a regression test: a
+// source directory whose name merely ends in ZAS_DIR (".zas"), such as
+// "docs.zas", used to be silently excluded from generation because the
+// walk's exclusion check matched the substring ".zas/" anywhere in the
+// path, not just the real ".zas" directory.
+func TestGenerateDirNameEndingInZasDirNotExcluded(t *testing.T) {
+	newTestSite(t, "site")
+	if err := os.MkdirAll("docs.zas", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join("docs.zas", "page.md"), []byte("# Page\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := generate(t); err != nil {
+		t.Fatalf("generate() error = %v, want nil", err)
+	}
+	assertDeployHas(t, filepath.Join("docs.zas", "page.html"))
+}
+
 func TestGenerateSkipsNestedHiddenDirectory(t *testing.T) {
 	newTestSite(t, "site")
 	if err := os.MkdirAll(filepath.Join("sect", ".hidden"), 0o755); err != nil {

--- a/walk_test.go
+++ b/walk_test.go
@@ -104,3 +104,42 @@ func TestWalkDoesNotSkipDirAtRoot(t *testing.T) {
 		t.Fatalf(`walk(".") error = %v, want nil`, err)
 	}
 }
+
+// TestWalkDoesNotSkipDirEndingInZasDir is a regression test: a directory
+// whose name merely ends in ZAS_DIR (".zas"), such as "docs.zas", must not
+// be treated as the real ".zas" directory.
+func TestWalkDoesNotSkipDirEndingInZasDir(t *testing.T) {
+	t.Chdir(t.TempDir())
+	gen := &Generator{}
+	if err := os.Mkdir("docs.zas", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat("docs.zas")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := gen.walk("docs.zas", info, nil); err != nil {
+		t.Fatalf(`walk("docs.zas") error = %v, want nil`, err)
+	}
+}
+
+func TestPathHasComponent(t *testing.T) {
+	tests := []struct {
+		path      string
+		component string
+		want      bool
+	}{
+		{ZAS_DIR, ZAS_DIR, true},
+		{filepath.Join("sect", ZAS_DIR), ZAS_DIR, true},
+		{filepath.Join(ZAS_DIR, "config.yml"), ZAS_DIR, true},
+		{"docs.zas", ZAS_DIR, false},
+		{filepath.Join("docs.zas", "page.md"), ZAS_DIR, false},
+		{"myzasdir", ZAS_DIR, false},
+		{"foo.zaster", ZAS_DIR, false},
+	}
+	for _, tt := range tests {
+		if got := pathHasComponent(tt.path, tt.component); got != tt.want {
+			t.Errorf("pathHasComponent(%q, %q) = %v, want %v", tt.path, tt.component, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `walk`'s `.zas` exclusion used `strings.Contains(path, ".zas/")`, which matches that substring anywhere in a path, so a legitimate directory whose name merely ends in `.zas` (e.g. `docs.zas/page.md`) was silently excluded from generation with no error or warning. The hardcoded forward slash also meant it could never match on Windows.
- Replaced the check with `pathHasComponent`, which splits the path on `filepath.Separator` and looks for an exact `.zas` path component. `docs.zas/page.md` no longer matches; a real `.zas` directory, at any depth, still does.
- Kept the check rather than removing it: during an actual `filepath.Walk` run it's provably unreachable (Walk visits a directory before its children, so the existing dot-prefix check already returns `SkipDir` on `.zas`'s own base name first), but an existing unit test calls the walk function directly with a synthetic nested path whose base name isn't dot-prefixed, so dropping the check outright would have broken that test.

## Test plan
- [x] New test: directory ending in `.zas` (`docs.zas/page.md`) deploys normally (`TestGenerateDirNameEndingInZasDirNotExcluded`, end-to-end)
- [x] New test: same, at the `walk` unit level (`TestWalkDoesNotSkipDirEndingInZasDir`)
- [x] New test: table-driven coverage of the new helper, including component-boundary edge cases like `myzasdir` and `foo.zaster` (`TestPathHasComponent`)
- [x] Full existing suite still green, including the tests pinning real `.zas` exclusion (`TestWalkSkipsDeployDirectory`, `TestGenerateSkipsNestedHiddenDirectory`, etc.)
- [x] `go build ./...`, `go vet ./...`, `go test ./... -race` all clean (86 tests, 0 failures)