### PR TITLE
fix(generate): detect and reject colliding source-to-output mappings

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -125,6 +125,14 @@ type Generator struct {
 	// reapedDirs holds deploy paths reaper has RemoveAll'd during the
 	// current reap walk. The reap walk is single-threaded, so no mutex.
 	reapedDirs map[string]struct{}
+
+	// claimedOutputs maps each deploy output path claimed so far to the
+	// source path that claimed it, so two sources that render to the same
+	// output (e.g. foo.md and foo.html) don't both spawn a renderAsync
+	// goroutine and race to write it. Like reapedDirs, this is only
+	// touched from walk, whose own invocations are sequential, so no
+	// mutex is needed.
+	claimedOutputs map[string]string
 }
 
 /*
@@ -328,6 +336,15 @@ func (gen *Generator) walk(path string, info os.FileInfo, err error) (ierr error
 	if info.IsDir() {
 		ierr = os.MkdirAll(gen.BuildDeployPath(path), os.FileMode(ZAS_DEFAULT_DIR_PERM))
 	} else if gen.sourceIsNewer(path, info) {
+		outputPath := swapExtension(path, ".md", ".html")
+		if claimant, ok := gen.claimedOutputs[outputPath]; ok {
+			gen.recordErr(fmt.Errorf("%s: output path %q already claimed by %s, skipping", path, outputPath, claimant))
+			return
+		}
+		if gen.claimedOutputs == nil {
+			gen.claimedOutputs = make(map[string]string)
+		}
+		gen.claimedOutputs[outputPath] = path
 		if gen.Verbose {
 			fmt.Println("+", path)
 		}

--- a/generate_e2e_test.go
+++ b/generate_e2e_test.go
@@ -214,6 +214,67 @@ func TestGenerateSkipsNestedHiddenDirectory(t *testing.T) {
 	assertDeployMissing(t, ".zas")
 }
 
+// TestGenerateCollidingMDAndHTMLFailsDeterministically is a regression
+// test: a source .md and .html file in the same directory used to both
+// render to the identical deploy output path in concurrent goroutines,
+// picking a nondeterministic winner (or worse, an interleaved/corrupted
+// write) with no error at all. It must now fail the build and always
+// keep the same winner - the first file filepath.Walk visits, since only
+// that one ever gets a renderAsync goroutine spawned for it. This runs
+// several fresh builds to confirm the outcome is deterministic, not just
+// usually right; go test -race confirms there's no write race on the
+// shared output file either.
+func TestGenerateCollidingMDAndHTMLFailsDeterministically(t *testing.T) {
+	for range 5 {
+		t.Run("run", func(t *testing.T) {
+			newTestSite(t, "site")
+			if err := os.WriteFile("collide.md", []byte("# Marker A\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile("collide.html", []byte("<h1>Marker B</h1>\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			err := generate(t, fullGen)
+			if err == nil {
+				t.Fatal("generate() error = nil, want a collision error")
+			}
+			msg := err.Error()
+			for _, want := range []string{"collide.md", "collide.html"} {
+				if !strings.Contains(msg, want) {
+					t.Fatalf("generate() error = %q, want it to mention %q", msg, want)
+				}
+			}
+
+			out := readDeploy(t, "collide.html")
+			if !strings.Contains(out, "Marker B") || strings.Contains(out, "Marker A") {
+				t.Fatalf("collide.html = %q, want only the .html source's content", out)
+			}
+		})
+	}
+}
+
+// TestGenerateSurvivesCollisionElsewhereInSite confirms a collision
+// between two files doesn't block the rest of the site: every other page
+// must still render even though the build's overall error return still
+// signals the collision.
+func TestGenerateSurvivesCollisionElsewhereInSite(t *testing.T) {
+	newTestSite(t, "site")
+	if err := os.WriteFile("collide.md", []byte("# Marker A\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile("collide.html", []byte("<h1>Marker B</h1>\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := generate(t, fullGen); err == nil {
+		t.Fatal("generate() error = nil, want a collision error")
+	}
+	assertDeployHas(t, "index.html")
+	assertDeployHas(t, "about.html")
+	assertDeployHas(t, filepath.Join("sub", "page.html"))
+	assertDeployHas(t, "collide.html")
+}
+
 func TestGenerateFailsOutsideRepository(t *testing.T) {
 	t.Chdir(t.TempDir())
 	err := generate(t)

--- a/walk_test.go
+++ b/walk_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -120,6 +121,35 @@ func TestWalkDoesNotSkipDirEndingInZasDir(t *testing.T) {
 	}
 	if err := gen.walk("docs.zas", info, nil); err != nil {
 		t.Fatalf(`walk("docs.zas") error = %v, want nil`, err)
+	}
+}
+
+// TestWalkRecordsCollisionAndSkipsSecondGoroutine is a regression test: a
+// source file whose deploy output path was already claimed by another
+// source (e.g. foo.html claiming foo.html before foo.md tries to, since
+// swapExtension maps both to the same output) must not get a second
+// renderAsync goroutine spawned for it - that's what let two goroutines
+// race to write the same output file. It must instead record an error
+// naming both files and return without touching gen.wg.
+func TestWalkRecordsCollisionAndSkipsSecondGoroutine(t *testing.T) {
+	t.Chdir(t.TempDir())
+	gen := &Generator{claimedOutputs: map[string]string{"foo.html": "foo.html"}}
+	if err := os.WriteFile("foo.md", nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat("foo.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := gen.walk("foo.md", info, nil); err != nil {
+		t.Fatalf("walk(%q) error = %v, want nil", "foo.md", err)
+	}
+	gen.wg.Wait()
+	if len(gen.errs) != 1 {
+		t.Fatalf("errs = %v, want exactly 1 collision error", gen.errs)
+	}
+	if msg := gen.errs[0].Error(); !strings.Contains(msg, "foo.md") || !strings.Contains(msg, "foo.html") {
+		t.Fatalf("errs[0] = %q, want it to mention both foo.md and foo.html", msg)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `walk` spawned a `renderAsync` goroutine for every source file needing (re)render, computing its deploy output path via `swapExtension`. Two sources that map to the same output (most commonly `foo.md` and `foo.html` in the same directory, since `swapExtension` maps both to `foo.html`) each got their own goroutine and raced to open and `O_TRUNC` the same output file, with no collision detection - the deployed result was a nondeterministic winner across runs, or worse, interleaved content from two simultaneous writers.
- `walk` now claims each output path in a new `Generator.claimedOutputs` map before spawning a goroutine for it. A source whose output is already claimed by a different source records an error through the existing `recordErr`/`errs` aggregation (naming both files and the shared path) and is skipped instead of spawned, so only one goroutine ever touches the contested file. Unrelated files still render normally, and the build's error return/exit code now reflects the collision instead of silently succeeding.
- `claimedOutputs` needs no mutex: it's only touched inside `walk`, and `walk`'s own invocations are strictly sequential (`filepath.Walk` drives them one at a time on the caller's goroutine) - the concurrency lives entirely in the `renderAsync` goroutines it spawns, which never touch this map. This mirrors the existing `reapedDirs` field's synchronization reasoning.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./... -race` (89 top-level tests, up from 86)
- [x] `TestWalkRecordsCollisionAndSkipsSecondGoroutine` unit-tests the claim-collision branch directly, without spawning a real render goroutine
- [x] `TestGenerateCollidingMDAndHTMLFailsDeterministically` drives the full `Generator.Run` pipeline across 5 fresh builds to confirm the failure and its winning output are deterministic, not just usually correct
- [x] `TestGenerateSurvivesCollisionElsewhereInSite` confirms unrelated pages in the same site still render despite the collision
- [x] Manually reproduced pre-fix (10 runs, nondeterministic winner between two markers, no warning) and post-fix (10 runs, deterministic failure with a clear message naming both files, exit code 1)