### PR TITLE
fix(generate): invalidate incremental builds on layout/config/i18n/.zas.yml changes

### DIFF
--- a/dependency_staleness_e2e_test.go
+++ b/dependency_staleness_e2e_test.go
@@ -1,0 +1,112 @@
+package zas
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// End-to-end tests proving sourceIsNewer invalidates pages when a shared
+// dependency changes, not just when the page's own source file does.
+
+func TestGenerateLayoutChangeInvalidatesEveryPage(t *testing.T) {
+	newTestSite(t, "site")
+	ageSources(t, -time.Hour)
+	if err := generate(t); err != nil {
+		t.Fatalf("first generate() error = %v, want nil", err)
+	}
+
+	layout := filepath.Join(".zas", "layout.html")
+	data, err := os.ReadFile(layout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated := strings.Replace(string(data), "<body>", `<body><p class="marker">layout-v2</p>`, 1)
+	if updated == string(data) {
+		t.Fatal("test fixture layout.html has no <body> tag to mark")
+	}
+	if err := os.WriteFile(layout, []byte(updated), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	touchFuture(t, layout)
+
+	if err := generate(t); err != nil {
+		t.Fatalf("second generate() error = %v, want nil", err)
+	}
+
+	for _, page := range []string{"about.html", "index.html", filepath.Join("sub", "page.html")} {
+		if out := readDeploy(t, page); !strings.Contains(out, "layout-v2") {
+			t.Fatalf("%s = %q, want it to reflect the edited layout", page, out)
+		}
+	}
+}
+
+func TestGenerateConfigChangeInvalidatesEveryPage(t *testing.T) {
+	newTestSite(t, "site")
+	ageSources(t, -time.Hour)
+	if err := generate(t); err != nil {
+		t.Fatalf("first generate() error = %v, want nil", err)
+	}
+	if out := readDeploy(t, "about.html"); !strings.Contains(out, "http://example.com") {
+		t.Fatalf("about.html = %q, want it to contain the original baseurl", out)
+	}
+
+	config := filepath.Join(".zas", "config.yml")
+	data, err := os.ReadFile(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated := strings.Replace(string(data), "http://example.com", "http://updated.example.com", 1)
+	if updated == string(data) {
+		t.Fatal("test fixture config.yml has no baseurl to update")
+	}
+	if err := os.WriteFile(config, []byte(updated), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	touchFuture(t, config)
+
+	if err := generate(t); err != nil {
+		t.Fatalf("second generate() error = %v, want nil", err)
+	}
+
+	for _, page := range []string{"about.html", "index.html", filepath.Join("sub", "page.html")} {
+		out := readDeploy(t, page)
+		if !strings.Contains(out, "http://updated.example.com") {
+			t.Fatalf("%s = %q, want it to reflect the updated baseurl", page, out)
+		}
+	}
+}
+
+func TestGenerateI18nChangeInvalidatesEveryPage(t *testing.T) {
+	newTestSite(t, "site")
+	ageSources(t, -time.Hour)
+	if err := generate(t); err != nil {
+		t.Fatalf("first generate() error = %v, want nil", err)
+	}
+	if out := readDeploy(t, "about.html"); !strings.Contains(out, "Hello") {
+		t.Fatalf("about.html = %q, want it to contain the original translation", out)
+	}
+
+	i18n := filepath.Join(".zas", "i18n.yml")
+	if err := os.WriteFile(i18n, []byte("greeting:\n  en: Hi\n  es: Hola\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	touchFuture(t, i18n)
+
+	if err := generate(t); err != nil {
+		t.Fatalf("second generate() error = %v, want nil", err)
+	}
+
+	// about.html (root, language "en") and sub/page.html (its own
+	// .zas.yml sets language "es") both embed the layout's {{.E
+	// "greeting"}}, so both must pick up the new translation - proving
+	// i18n.yml invalidation is global, not scoped to one page.
+	if out := readDeploy(t, "about.html"); !strings.Contains(out, "Hi") || strings.Contains(out, "Hello") {
+		t.Fatalf("about.html = %q, want the updated \"Hi\" translation", out)
+	}
+	if out := readDeploy(t, filepath.Join("sub", "page.html")); !strings.Contains(out, "Hola") {
+		t.Fatalf("sub/page.html = %q, want it regenerated with the (unchanged) Hola translation", out)
+	}
+}

--- a/dependency_staleness_e2e_test.go
+++ b/dependency_staleness_e2e_test.go
@@ -110,3 +110,81 @@ func TestGenerateI18nChangeInvalidatesEveryPage(t *testing.T) {
 		t.Fatalf("sub/page.html = %q, want it regenerated with the (unchanged) Hola translation", out)
 	}
 }
+
+// TestGenerateZasYMLScopesInvalidationToItsSubtree is the trickiest case:
+// editing a .zas.yml must regenerate pages under its own directory without
+// touching pages elsewhere in the site, including an unrelated sibling
+// subdirectory that has no .zas.yml of its own.
+func TestGenerateZasYMLScopesInvalidationToItsSubtree(t *testing.T) {
+	newTestSite(t, "site")
+	if err := os.MkdirAll("other", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join("other", "index.md"), []byte("# Other\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ageSources(t, -time.Hour)
+	if err := generate(t); err != nil {
+		t.Fatalf("first generate() error = %v, want nil", err)
+	}
+	if out := readDeploy(t, filepath.Join("sub", "page.html")); !strings.Contains(out, "Hola") {
+		t.Fatalf("sub/page.html = %q, want it to contain the original Hola translation", out)
+	}
+
+	subTarget := filepath.Join(".zas", "deploy", "sub", "page.html")
+	otherTarget := filepath.Join(".zas", "deploy", "other", "index.html")
+	aboutTarget := filepath.Join(".zas", "deploy", "about.html")
+
+	subBefore, err := os.Stat(subTarget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherBefore, err := os.Stat(otherTarget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	aboutBefore, err := os.Stat(aboutTarget)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	zasYML := filepath.Join("sub", ZAS_DIR_CONF_FILE)
+	if err := os.WriteFile(zasYML, []byte("language: en\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	touchFuture(t, zasYML)
+
+	if err := generate(t); err != nil {
+		t.Fatalf("second generate() error = %v, want nil", err)
+	}
+
+	// Direction 1: sub/page.html is under the changed .zas.yml's
+	// directory, so it must regenerate and reflect the new language.
+	subAfter, err := os.Stat(subTarget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if subBefore.ModTime().Equal(subAfter.ModTime()) {
+		t.Fatalf("sub/page.html mtime unchanged after editing sub/.zas.yml, want it regenerated: mtime=%v", subBefore.ModTime())
+	}
+	if out := readDeploy(t, filepath.Join("sub", "page.html")); !strings.Contains(out, "Hello") || strings.Contains(out, "Hola") {
+		t.Fatalf("sub/page.html = %q, want it to reflect the new .zas.yml language (Hello, not Hola)", out)
+	}
+
+	// Direction 2: other/index.html and about.html are outside sub/, so
+	// editing sub/.zas.yml must not touch them.
+	otherAfter, err := os.Stat(otherTarget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !otherBefore.ModTime().Equal(otherAfter.ModTime()) {
+		t.Fatalf("other/index.html mtime changed after editing sub/.zas.yml, want unaffected sibling directory: before=%v after=%v", otherBefore.ModTime(), otherAfter.ModTime())
+	}
+	aboutAfter, err := os.Stat(aboutTarget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !aboutBefore.ModTime().Equal(aboutAfter.ModTime()) {
+		t.Fatalf("about.html mtime changed after editing sub/.zas.yml, want unaffected: before=%v after=%v", aboutBefore.ModTime(), aboutAfter.ModTime())
+	}
+}

--- a/dirconfig_race_test.go
+++ b/dirconfig_race_test.go
@@ -38,7 +38,7 @@ func TestLoadZasDirectoryConfigConcurrent(t *testing.T) {
 			wg.Add(1)
 			go func(path, wantLang string) {
 				defer wg.Done()
-				cfg, err := gen.loadZasDirectoryConfig(path)
+				cfg, _, err := gen.loadZasDirectoryConfig(path)
 				if err != nil {
 					errCh <- fmt.Errorf("%s: %w", path, err)
 					return

--- a/generate.go
+++ b/generate.go
@@ -32,6 +32,7 @@ import (
 	"strings"
 	"sync"
 	ttext "text/template"
+	"time"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/melvinmt/gt"
@@ -111,6 +112,16 @@ type Generator struct {
 	Layout *thtml.Template
 	// i18n helper.
 	I18n *gt.Build
+	// layoutModTime, configModTime, and i18nModTime are the shared
+	// dependency files' mtimes, each captured once during Run's startup
+	// phase (parseLayout, Run, loadI18N) instead of being stat'd per page,
+	// since a site can have thousands of pages all depending on the same
+	// three files. sourceIsNewer treats a page as stale if any is newer
+	// than the page's deploy output. Zero value (e.g. i18n.yml absent)
+	// never counts as newer than a real deploy output.
+	layoutModTime time.Time
+	configModTime time.Time
+	i18nModTime   time.Time
 	// ZasDirectoryConfigs cache
 	cachedZasDirectoryConfigs map[string]ConfigSection
 	// Guards cachedZasDirectoryConfigs, read and written from many renderAsync goroutines.
@@ -237,6 +248,9 @@ func (gen *Generator) Run() error {
 		return err
 	}
 	gen.Config = cfg
+	if info, statErr := os.Stat(ZAS_CONF_FILE); statErr == nil {
+		gen.configModTime = info.ModTime()
+	}
 	gen.wg.Add(3)
 	go gen.parseLayout()
 	go gen.loadI18N()
@@ -274,6 +288,9 @@ func (gen *Generator) parseLayout() {
 	defer gen.wg.Done()
 
 	layout := gen.Config.GetZString("layout")
+	if info, statErr := os.Stat(layout); statErr == nil {
+		gen.layoutModTime = info.ModTime()
+	}
 	if gen.Layout, err = thtml.New(filepath.Base(layout)).Funcs(helpers).ParseFiles(layout); err != nil {
 		gen.recordErr(err)
 	}
@@ -291,6 +308,9 @@ func (gen *Generator) loadI18N() {
 	gen.I18n = &gt.Build{
 		Index:  i18nStrings,
 		Origin: mainlang,
+	}
+	if info, statErr := os.Stat(ZAS_I18N_FILE); statErr == nil {
+		gen.i18nModTime = info.ModTime()
 	}
 }
 
@@ -436,7 +456,16 @@ func (gen *Generator) sourceIsNewer(path string, sourceInfo os.FileInfo) bool {
 	if err != nil {
 		return true
 	}
-	return sourceInfo.ModTime().UnixNano() >= destinationInfo.ModTime().UnixNano()
+	destModTime := destinationInfo.ModTime()
+	if sourceInfo.ModTime().UnixNano() >= destModTime.UnixNano() {
+		return true
+	}
+	// .Before, not UnixNano: a dependency that was never stat'd (e.g. no
+	// i18n.yml) leaves its mtime at time.Time's zero value, and
+	// zero.UnixNano() is documented as undefined for dates this far out -
+	// .Before/.After stay well defined and correctly treat "never stat'd"
+	// as "not newer".
+	return !gen.layoutModTime.Before(destModTime) || !gen.configModTime.Before(destModTime) || !gen.i18nModTime.Before(destModTime)
 }
 
 /*

--- a/generate.go
+++ b/generate.go
@@ -123,7 +123,7 @@ type Generator struct {
 	configModTime time.Time
 	i18nModTime   time.Time
 	// ZasDirectoryConfigs cache
-	cachedZasDirectoryConfigs map[string]ConfigSection
+	cachedZasDirectoryConfigs map[string]dirConfigEntry
 	// Guards cachedZasDirectoryConfigs, read and written from many renderAsync goroutines.
 	dirConfigMu sync.Mutex
 
@@ -461,11 +461,15 @@ func (gen *Generator) sourceIsNewer(path string, sourceInfo os.FileInfo) bool {
 		return true
 	}
 	// .Before, not UnixNano: a dependency that was never stat'd (e.g. no
-	// i18n.yml) leaves its mtime at time.Time's zero value, and
-	// zero.UnixNano() is documented as undefined for dates this far out -
-	// .Before/.After stay well defined and correctly treat "never stat'd"
-	// as "not newer".
-	return !gen.layoutModTime.Before(destModTime) || !gen.configModTime.Before(destModTime) || !gen.i18nModTime.Before(destModTime)
+	// i18n.yml, or no .zas.yml anywhere in path's ancestry) leaves its
+	// mtime at time.Time's zero value, and zero.UnixNano() is documented
+	// as undefined for dates this far out - .Before/.After stay well
+	// defined and correctly treat "never stat'd" as "not newer".
+	if !gen.layoutModTime.Before(destModTime) || !gen.configModTime.Before(destModTime) || !gen.i18nModTime.Before(destModTime) {
+		return true
+	}
+	_, dirModTime, _ := gen.loadZasDirectoryConfig(path)
+	return !dirModTime.Before(destModTime)
 }
 
 /*
@@ -500,52 +504,75 @@ func (gen *Generator) renderHTML(path string) (err error) {
 	return gen.render(path, input)
 }
 
+// dirConfigEntry is a cached loadZasDirectoryConfig resolution: config is
+// nil when no ZAS_DIR_CONF_FILE exists anywhere in the queried directory's
+// ancestry, and modTime is its zero value in that case too.
+type dirConfigEntry struct {
+	config  ConfigSection
+	modTime time.Time
+}
+
 /*
  * Loads ZAS_DIR_CONF_FILE (as defined in constants.go) from current
- * directory or previously found ones.
+ * directory or previously found ones, along with that file's own mtime.
  * It must be a YAML file.
+ *
+ * Every directory visited while resolving currentpath is cached, not just
+ * the one where ZAS_DIR_CONF_FILE was actually found - including a miss
+ * that bottoms out at ".". Without that, a directory with no directory
+ * config anywhere in its ancestry (the common case) would redo the whole
+ * upward walk on every call instead of hitting the cache after the first.
  */
-func (gen *Generator) loadZasDirectoryConfig(currentpath string) (config ConfigSection, err error) {
+func (gen *Generator) loadZasDirectoryConfig(currentpath string) (config ConfigSection, modTime time.Time, err error) {
 	path := filepath.Dir(currentpath)
-	if config, ok := gen.getCachedDirConfig(path); ok {
-		return config, nil
+	if entry, ok := gen.getCachedDirConfig(path); ok {
+		if entry.config == nil {
+			return nil, time.Time{}, os.ErrNotExist
+		}
+		return entry.config, entry.modTime, nil
 	}
-	data, err := os.ReadFile(fmt.Sprintf("%s/%s", path, ZAS_DIR_CONF_FILE))
+	confPath := fmt.Sprintf("%s/%s", path, ZAS_DIR_CONF_FILE)
+	data, err := os.ReadFile(confPath)
 	if err != nil {
 		// Maybe .zas.yml is in an upper directory (already cached or not),
-		// so we call this recursively.
-		// Unless we are at current working directory.
-		if path == "." {
-			return nil, err
+		// so we call this recursively. Unless we are at current working
+		// directory.
+		var entry dirConfigEntry
+		if path != "." {
+			entry.config, entry.modTime, err = gen.loadZasDirectoryConfig(path)
 		}
-		return gen.loadZasDirectoryConfig(path)
+		gen.setCachedDirConfig(path, entry)
+		return entry.config, entry.modTime, err
 	}
 	config = make(ConfigSection)
 	_ = yaml.Unmarshal(data, &config)
-	gen.setCachedDirConfig(path, config)
-	return config, nil
+	if info, statErr := os.Stat(confPath); statErr == nil {
+		modTime = info.ModTime()
+	}
+	gen.setCachedDirConfig(path, dirConfigEntry{config: config, modTime: modTime})
+	return config, modTime, nil
 }
 
 /*
  * Reads cachedZasDirectoryConfigs, safe for concurrent use.
  */
-func (gen *Generator) getCachedDirConfig(path string) (config ConfigSection, ok bool) {
+func (gen *Generator) getCachedDirConfig(path string) (entry dirConfigEntry, ok bool) {
 	gen.dirConfigMu.Lock()
 	defer gen.dirConfigMu.Unlock()
-	config, ok = gen.cachedZasDirectoryConfigs[path]
+	entry, ok = gen.cachedZasDirectoryConfigs[path]
 	return
 }
 
 /*
  * Writes cachedZasDirectoryConfigs, safe for concurrent use.
  */
-func (gen *Generator) setCachedDirConfig(path string, config ConfigSection) {
+func (gen *Generator) setCachedDirConfig(path string, entry dirConfigEntry) {
 	gen.dirConfigMu.Lock()
 	defer gen.dirConfigMu.Unlock()
 	if gen.cachedZasDirectoryConfigs == nil {
-		gen.cachedZasDirectoryConfigs = make(map[string]ConfigSection)
+		gen.cachedZasDirectoryConfigs = make(map[string]dirConfigEntry)
 	}
-	gen.cachedZasDirectoryConfigs[path] = config
+	gen.cachedZasDirectoryConfigs[path] = entry
 }
 
 /*
@@ -560,7 +587,7 @@ func (gen *Generator) render(path string, input []byte) (err error) {
 	var processed bytes.Buffer
 	// Building context and rendering template.
 	data := NewZasData(path, gen)
-	data.Directory, _ = gen.loadZasDirectoryConfig(path)
+	data.Directory, _, _ = gen.loadZasDirectoryConfig(path)
 	// Pass a pointer: text/template only sees pointer-receiver methods
 	// (Title, E, URL, ...) on an addressable value, and a plain "data" here
 	// is not addressable.

--- a/harness_test.go
+++ b/harness_test.go
@@ -119,3 +119,15 @@ func ageSources(t *testing.T, d time.Duration) {
 		t.Fatal(err)
 	}
 }
+
+// touchFuture sets path's mtime an hour ahead of time.Now(), so a
+// dependency file rewritten after the first generate is unambiguously
+// newer than the deploy output that first generate just wrote, regardless
+// of filesystem mtime resolution.
+func touchFuture(t *testing.T, path string) {
+	t.Helper()
+	when := time.Now().Add(time.Hour)
+	if err := os.Chtimes(path, when, when); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

`sourceIsNewer` was the sole staleness check for incremental builds (`zas generate` without `-full`), and it only ever compared a page's own source mtime against its own deploy output. Editing any of the files a page's rendering actually depends on — the shared layout template, `.zas/config.yml`, `.zas/i18n.yml`, or a directory-level `.zas.yml` — left affected pages silently stale, with no error or warning even under `-verbose`.

- Layout, config, and i18n changes now invalidate every page: each file's mtime is stat'd once during `Run`'s startup phase (not per page) and cached on `Generator`, then compared against each page's deploy output alongside the existing source-mtime check.
- `.zas.yml` changes invalidate only pages in that directory and its subdirectories, not the whole site: `loadZasDirectoryConfig`'s existing cache is extended in place to also track each resolved `.zas.yml`'s own mtime, reusing the same upward directory walk pages already use to load their directory config rather than adding a second mechanism.

Split into two commits: one for the three globally-invalidating dependencies (layout/config/i18n), one for the directory-scoped `.zas.yml` case.

**Known, deliberate gap — not addressed in this PR:** dependency tracking through `<embed>` tags is out of scope here. Knowing what a page embeds requires actually parsing/rendering it, and there's no existing mechanism in this codebase to persist a "what did page X embed last time" graph across runs. That's a meaningfully larger undertaking than the rest of this fix and doesn't fit the same shape, so it's left as a documented gap rather than a partial/half-working implementation. Editing a file that's only reachable through another page's `<embed>` tag still won't invalidate the embedding page on an incremental build.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` all clean
- [x] `go test ./... -race` clean, full suite (93 tests: 89 pre-existing + 4 new)
- [x] New: `TestGenerateLayoutChangeInvalidatesEveryPage` — edit `layout.html` only, incremental build, every page regenerates and reflects the new layout
- [x] New: `TestGenerateConfigChangeInvalidatesEveryPage` — edit `config.yml`'s `site.baseurl` only, incremental build, pages reflect the new value
- [x] New: `TestGenerateI18nChangeInvalidatesEveryPage` — edit `i18n.yml` only, incremental build, translated content updates globally (root page and a page under a directory-scoped language both pick up the change)
- [x] New: `TestGenerateZasYMLScopesInvalidationToItsSubtree` — edit a subdirectory's `.zas.yml`, incremental build: pages under that directory regenerate (mtime changes, content reflects new config) **and** pages in an unrelated sibling directory do not (mtime unchanged) — both directions asserted in one test
- [x] Regression: `TestGenerateIncrementalSkipsUnchanged` (pre-existing) passes unmodified — the new dependency checks don't cause false-positive staleness when nothing changed
- [x] Manually reproduced the original bug against the pre-fix binary (edited `.zas/layout.html`, confirmed no regeneration and stale deploy output), then confirmed the fix resolves it
- [x] Manually reproduced the `.zas.yml` scoping case against the built binary in both directions (only the page under the edited directory's mtime changes)