### PR TITLE
fix(generate): write deploy output atomically to survive interruption

### DIFF
--- a/atomic_write_e2e_test.go
+++ b/atomic_write_e2e_test.go
@@ -40,6 +40,29 @@ func TestGenerateSurvivesStrayLeftoverTempFile(t *testing.T) {
 	}
 }
 
+// TestGenerateOutputHasDefaultPermissions is a plain regression check that
+// atomicWriteFile's explicit Chmod didn't change anything observable about
+// the normal, uninterrupted path: a rendered page (through Generate) and a
+// copied asset (through copy) must both still end up at the deploy tree's
+// usual 0644, matching ZAS_DEFAULT_FILE_PERM, exactly as the old direct
+// os.OpenFile(..., ZAS_DEFAULT_FILE_PERM) calls produced.
+func TestGenerateOutputHasDefaultPermissions(t *testing.T) {
+	newTestSite(t, "site")
+	if err := generate(t); err != nil {
+		t.Fatalf("generate() error = %v, want nil", err)
+	}
+
+	for _, rel := range []string{"about.html", filepath.Join("assets", "data.json")} {
+		info, err := os.Stat(filepath.Join(".zas", "deploy", rel))
+		if err != nil {
+			t.Fatalf("stat(%q): %v", rel, err)
+		}
+		if perm := info.Mode().Perm(); perm != os.FileMode(ZAS_DEFAULT_FILE_PERM) {
+			t.Errorf("%s permissions = %o, want %o", rel, perm, ZAS_DEFAULT_FILE_PERM)
+		}
+	}
+}
+
 const (
 	killFixtureNPages    = 3000
 	killFixtureNAssets   = 25

--- a/atomic_write_e2e_test.go
+++ b/atomic_write_e2e_test.go
@@ -1,0 +1,217 @@
+package zas
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestGenerateSurvivesStrayLeftoverTempFile simulates what a prior crash
+// would leave behind: a temporary file dropped mid-atomic-write, in the same
+// directory atomicWriteFile itself would use, before the rename that would
+// have replaced it ever ran. A subsequent run must not be confused by it -
+// reaper has no matching source for it, so it must simply be removed like
+// any other orphaned deploy file.
+func TestGenerateSurvivesStrayLeftoverTempFile(t *testing.T) {
+	newTestSite(t, "site")
+	if err := generate(t); err != nil {
+		t.Fatalf("first generate() error = %v, want nil", err)
+	}
+
+	strayPath := filepath.Join(".zas", "deploy", ".about.html.999999999.tmp")
+	if err := os.WriteFile(strayPath, []byte("leftover from a simulated crash, before its rename"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := generate(t); err != nil {
+		t.Fatalf("second generate() error = %v, want nil", err)
+	}
+
+	if _, err := os.Stat(strayPath); !os.IsNotExist(err) {
+		t.Fatalf("stray temp file still present after a subsequent run (stat err = %v), want reaped", err)
+	}
+	if out := readDeploy(t, "about.html"); !strings.Contains(out, "This is the about page.") {
+		t.Fatalf("about.html = %q, want it to still contain the body text", out)
+	}
+}
+
+const (
+	killFixtureNPages    = 3000
+	killFixtureNAssets   = 25
+	killFixtureAssetSize = 25 * 1024 * 1024
+)
+
+// buildAtomicWriteKillFixture writes a site with many markdown pages and a
+// handful of sizeable binary assets, so a real, externally-delivered kill
+// has a wide window to land while at least one renderAsync goroutine is
+// between opening its temporary file (via atomicWriteFile) and renaming it
+// onto the real destination. Dynamically generated per CONTRIBUTING.md
+// (a loop writing many files doesn't belong in a checked-in fixture); only
+// the static config/layout pair comes from testdata/walk-error-base.
+func buildAtomicWriteKillFixture(t *testing.T, dir string) {
+	t.Helper()
+	must := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	copyFixture(t, "walk-error-base", dir)
+
+	for i := range killFixtureNPages {
+		name := fmt.Sprintf("page-%04d.md", i)
+		body := fmt.Sprintf("# Page %d\n\n%s\n", i, strings.Repeat("Lorem ipsum dolor sit amet. ", 20))
+		must(os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644))
+	}
+	data := bytes.Repeat([]byte{0xAB}, killFixtureAssetSize)
+	for i := range killFixtureNAssets {
+		name := fmt.Sprintf("asset-%03d.bin", i)
+		must(os.WriteFile(filepath.Join(dir, name), data, 0o644))
+	}
+}
+
+// countDeployedFiles counts regular (non-directory) entries anywhere under
+// root, ignoring read errors from entries that may vanish mid-walk.
+func countDeployedFiles(root string) int {
+	n := 0
+	_ = filepath.Walk(root, func(_ string, info os.FileInfo, err error) error {
+		if err == nil && info != nil && !info.IsDir() {
+			n++
+		}
+		return nil
+	})
+	return n
+}
+
+// TestGenerateKillMidRunNeverLeavesPartialFinalFile is the end-to-end proof
+// that atomicWriteFile makes writes crash-safe: a real SIGKILL delivered to
+// a subprocess genuinely mid-run - a strictly more general interruption than
+// the walk error TestGenerateWalkErrorDrainsInFlightGoroutines exercises,
+// since it kills the process outright regardless of any in-process goroutine
+// draining - must never leave a partially-written file observable at any
+// final (non-temporary) deploy path. It reuses that same test's subprocess
+// re-exec harness (TestMain / runWalkErrorHelperProcess / TestHelperHarness).
+func TestGenerateKillMidRunNeverLeavesPartialFinalFile(t *testing.T) {
+	dir := t.TempDir()
+	buildAtomicWriteKillFixture(t, dir)
+	const total = killFixtureNPages + killFixtureNAssets
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestHelperHarness$")
+	cmd.Env = append(os.Environ(), walkErrorHelperEnv+"=1")
+	cmd.Dir = dir
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	deployRoot := filepath.Join(dir, ZAS_DIR, "deploy")
+	deadline := time.Now().Add(30 * time.Second)
+	killed := false
+	for time.Now().Before(deadline) {
+		n := countDeployedFiles(deployRoot)
+		if n > total/10 && n < total*8/10 {
+			killed = cmd.Process.Kill() == nil
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if !killed {
+		_ = cmd.Process.Kill()
+	}
+	_ = cmd.Wait()
+	if !killed {
+		t.Skip("could not land the kill mid-run on this machine (finished too fast); rerun to try again")
+	}
+
+	// The core property under test: every FINAL-named file in deploy (i.e.
+	// every path that isn't one of atomicWriteFile's own leftover ".tmp"
+	// files) is either a complete render/copy or doesn't exist at all -
+	// never truncated or partial. Leftover ".tmp" files are expected crash
+	// residue, not a failure - counting them is a positive control, proving
+	// the kill actually landed while a write was in flight rather than
+	// passing vacuously because it landed in a quiet moment.
+	checked, strayTmp := 0, 0
+	walkErr := filepath.Walk(deployRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			t.Errorf("walking deploy: %v", err)
+			return nil
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(path, ".tmp") {
+			strayTmp++
+			return nil
+		}
+		checked++
+		switch {
+		case strings.HasSuffix(path, ".html"):
+			content, rerr := os.ReadFile(path)
+			if rerr != nil {
+				t.Errorf("ReadFile(%q): %v", path, rerr)
+				return nil
+			}
+			if !strings.Contains(string(content), "</html>") {
+				t.Errorf("%s: incomplete render, %d bytes, missing </html>", path, len(content))
+			}
+		case strings.HasSuffix(path, ".bin"):
+			if info.Size() != killFixtureAssetSize {
+				t.Errorf("%s: incomplete copy, %d of %d bytes", path, info.Size(), killFixtureAssetSize)
+			}
+		default:
+			t.Errorf("%s: unexpected entry in deploy", path)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walking deploy dir: %v", walkErr)
+	}
+	if checked == 0 {
+		t.Fatal("no final-path files were observed in deploy at all; fixture didn't exercise the in-flight scenario")
+	}
+	if strayTmp == 0 {
+		t.Skip("no leftover .tmp file found after the kill; the interruption didn't land mid-write, so this run didn't actually exercise the race - rerun")
+	}
+	t.Logf("verified %d final-path files in deploy after a mid-run kill, none truncated (and %d leftover temp files confirm the kill genuinely landed mid-write)", checked, strayTmp)
+
+	// A follow-up incremental run must succeed, must clean up any leftover
+	// temp files the kill left behind, and must leave every source with a
+	// complete output - unlike the pre-fix bug, nothing here can be
+	// permanently stuck, because no truncated file was ever left at a final
+	// path for sourceIsNewer to mistake as up to date.
+	t.Chdir(dir)
+	gen := &Generator{}
+	if err := gen.Run(); err != nil {
+		t.Fatalf("incremental rerun after kill: error = %v, want nil", err)
+	}
+	_ = filepath.Walk(deployRoot, func(path string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() && strings.HasSuffix(path, ".tmp") {
+			t.Errorf("leftover temp file survived a follow-up run: %s", path)
+		}
+		return nil
+	})
+	for i := range killFixtureNPages {
+		rel := fmt.Sprintf("page-%04d.html", i)
+		content, rerr := os.ReadFile(filepath.Join(deployRoot, rel))
+		if rerr != nil {
+			t.Fatalf("%s missing after follow-up run: %v", rel, rerr)
+		}
+		if !strings.Contains(string(content), "</html>") {
+			t.Errorf("%s still incomplete after follow-up run", rel)
+		}
+	}
+	for i := range killFixtureNAssets {
+		rel := fmt.Sprintf("asset-%03d.bin", i)
+		info, serr := os.Stat(filepath.Join(deployRoot, rel))
+		if serr != nil {
+			t.Fatalf("%s missing after follow-up run: %v", rel, serr)
+		}
+		if info.Size() != killFixtureAssetSize {
+			t.Errorf("%s still incomplete after follow-up run: %d of %d bytes", rel, info.Size(), killFixtureAssetSize)
+		}
+	}
+}

--- a/atomic_write_test.go
+++ b/atomic_write_test.go
@@ -1,0 +1,136 @@
+package zas
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// atomicWriteFile must never truncate or partially write the final
+// destination path: it only ever touches a temporary file in the same
+// directory, renaming it onto the destination once write fully succeeds.
+
+// assertNoStrayTempFiles confirms atomicWriteFile cleaned up after itself:
+// no leftover ".*.tmp" entry in dir.
+func assertNoStrayTempFiles(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Fatalf("stray temp file left behind in %s: %s", dir, e.Name())
+		}
+	}
+}
+
+func TestAtomicWriteFileLeavesExistingContentOnError(t *testing.T) {
+	gen := &Generator{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.txt")
+	original := "original content, must survive a failed write"
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	wantErr := errors.New("boom")
+	err := gen.atomicWriteFile(path, func(w io.Writer) error {
+		if _, werr := io.WriteString(w, "partial-new-bytes-that-must-never-land"); werr != nil {
+			return werr
+		}
+		return wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("atomicWriteFile() error = %v, want %v", err, wantErr)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != original {
+		t.Fatalf("destination content = %q, want untouched original %q", got, original)
+	}
+	assertNoStrayTempFiles(t, dir)
+}
+
+func TestAtomicWriteFileLeavesNoFileOnErrorWhenAbsent(t *testing.T) {
+	gen := &Generator{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.txt")
+
+	wantErr := errors.New("boom")
+	err := gen.atomicWriteFile(path, func(w io.Writer) error {
+		_, _ = io.WriteString(w, "partial-bytes-that-must-never-land")
+		return wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("atomicWriteFile() error = %v, want %v", err, wantErr)
+	}
+
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("destination exists after a failed write (stat err = %v), want absent", statErr)
+	}
+	assertNoStrayTempFiles(t, dir)
+}
+
+func TestAtomicWriteFileSuccessSetsDefaultPermissionsAndContent(t *testing.T) {
+	gen := &Generator{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.txt")
+	want := "hello atomic world"
+
+	err := gen.atomicWriteFile(path, func(w io.Writer) error {
+		_, werr := io.WriteString(w, want)
+		return werr
+	})
+	if err != nil {
+		t.Fatalf("atomicWriteFile() error = %v, want nil", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != os.FileMode(ZAS_DEFAULT_FILE_PERM) {
+		t.Fatalf("permissions = %o, want %o", perm, ZAS_DEFAULT_FILE_PERM)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Fatalf("content = %q, want %q", got, want)
+	}
+	assertNoStrayTempFiles(t, dir)
+}
+
+func TestAtomicWriteFileOverwritesExistingContentOnSuccess(t *testing.T) {
+	gen := &Generator{}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.txt")
+	if err := os.WriteFile(path, []byte("stale content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "fresh content"
+	err := gen.atomicWriteFile(path, func(w io.Writer) error {
+		_, werr := io.WriteString(w, want)
+		return werr
+	})
+	if err != nil {
+		t.Fatalf("atomicWriteFile() error = %v, want nil", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Fatalf("content = %q, want %q", got, want)
+	}
+	assertNoStrayTempFiles(t, dir)
+}

--- a/generate.go
+++ b/generate.go
@@ -176,6 +176,41 @@ func swapExtension(path, from, to string) string {
 	return strings.TrimSuffix(path, from) + to
 }
 
+// atomicWriteFile calls write with a temporary file in path's own directory
+// (same filesystem, so the rename below is atomic), then renames it onto
+// path once write fully succeeds. path itself is never opened or truncated,
+// so an interruption at any point - panic, crash, SIGKILL, power loss -
+// before the rename leaves it holding either its previous complete content
+// or nothing, never a partial write. On any error the temporary file is
+// removed instead of left behind.
+func (gen *Generator) atomicWriteFile(path string, write func(io.Writer) error) (err error) {
+	f, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := f.Name()
+	defer func() {
+		if err != nil {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err = write(f); err != nil {
+		_ = f.Close()
+		return err
+	}
+	// os.CreateTemp always creates with mode 0600, regardless of
+	// ZAS_DEFAULT_FILE_PERM, so the final file's permissions must be set
+	// explicitly before it replaces path.
+	if err = f.Chmod(os.FileMode(ZAS_DEFAULT_FILE_PERM)); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err = f.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
 // Generate renders and writes the file at data.Path using the given
 // template context.
 func (gen *Generator) Generate(_ string, data *ZasData) (err error) {
@@ -199,20 +234,9 @@ func (gen *Generator) Generate(_ string, data *ZasData) (err error) {
 			}
 		}
 	}
-	f, err := os.OpenFile(gen.BuildDeployPath(data.Path), os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(ZAS_DEFAULT_FILE_PERM))
-	if err != nil {
-		return
-	}
-	defer func() {
-		if cerr := f.Close(); cerr != nil && err == nil {
-			err = cerr
-		}
-	}()
-	err = html5.Render(f, doc.Get(0))
-	if err != nil {
-		return
-	}
-	return
+	return gen.atomicWriteFile(gen.BuildDeployPath(data.Path), func(w io.Writer) error {
+		return html5.Render(w, doc.Get(0))
+	})
 }
 
 // maxEmbedDepth bounds how many levels of <embed> an entry file may nest.
@@ -682,17 +706,10 @@ func (gen *Generator) copy(dstPath, srcPath string) (err error) {
 		return
 	}
 	defer func() { _ = src.Close() }()
-	dst, err := os.OpenFile(dstPath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, os.FileMode(ZAS_DEFAULT_FILE_PERM))
-	if err != nil {
-		return
-	}
-	defer func() {
-		if cerr := dst.Close(); cerr != nil && err == nil {
-			err = cerr
-		}
-	}()
-	_, err = io.Copy(dst, src)
-	return
+	return gen.atomicWriteFile(dstPath, func(w io.Writer) error {
+		_, err := io.Copy(w, src)
+		return err
+	})
 }
 
 // Markdown embeds a Markdown file.


### PR DESCRIPTION
## Summary

- `Generate` and `copy` used to write page/asset content straight to
  their final deploy path, opened with `O_TRUNC`. An interruption at
  any point mid-write (panic, disk-full, OOM kill, SIGKILL, power
  loss) left a truncated file at that path with a live mtime.
  Incremental mode's `sourceIsNewer` only compares mtimes, so the
  corrupt file was considered up to date forever - nothing short of
  `-full` ever regenerated it.
- Both functions now go through a new `atomicWriteFile` helper: write
  to a temp file in the destination's own directory, then `os.Rename`
  it onto the real path only once the write fully succeeds. Explicit
  chmod before the rename keeps the final permissions at 0644 (temp
  files default to 0600). Any error before the rename removes the temp
  file instead of leaving it behind. As a small side effect of
  rewriting these open calls, both also drop the `O_RDWR` flag neither
  function ever needed.

## Test plan

- [x] Reproduced the bug first: a real `SIGKILL` to a subprocess
      genuinely mid-run, on the pre-fix code, reliably left partially
      copied assets and zero-byte truncated pages at their final
      deploy path (verified 3/3 runs).
- [x] Same kill technique against the fixed code, verified 5/5 runs:
      never a partial file at a final path, only an orphaned temp file
      that a follow-up run's existing reaper logic cleans up with no
      special-casing needed.
- [x] Added `TestGenerateKillMidRunNeverLeavesPartialFinalFile`
      (subprocess-kill e2e regression test, reusing the existing
      walk-error test's re-exec harness).
- [x] Added structural tests for `atomicWriteFile`: error mid-write
      leaves prior content (or absence) untouched, success sets 0644
      permissions and correct content.
- [x] Added `TestGenerateSurvivesStrayLeftoverTempFile`: a simulated
      crash-leftover temp file doesn't break a subsequent run.
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...`,
      `go test ./... -race` all clean, full suite (101 tests, up from
      95).