### PR TITLE
fix(cmd/zas): stop panicking when an external plugin command fails

### DIFF
--- a/cmd/zas/main.go
+++ b/cmd/zas/main.go
@@ -59,8 +59,10 @@ func init() {
 
 func main() {
 	runtime.GOMAXPROCS(runtime.NumCPU())
+	os.Exit(run(os.Args[1:]))
+}
 
-	args := os.Args[1:]
+func run(args []string) int {
 	if len(args) == 0 {
 		// If no subcommand is provided, we default to "generate".
 		args = []string{"generate"}
@@ -77,28 +79,43 @@ func main() {
 		if cmd.Name == command && cmd.Run != nil {
 			if err := cmd.Flag.Parse(args[1:]); err != nil {
 				if errors.Is(err, flag.ErrHelp) {
-					os.Exit(0)
+					return 0
 				}
-				os.Exit(2)
+				return 2
 			}
 
 			if err := cmd.Run(); err != nil {
 				fmt.Fprintf(os.Stderr, "fatal: %s\n", err)
-				os.Exit(1)
+				return 1
 			}
 
-			os.Exit(0)
+			return 0
 		}
 	}
 
-	// If not internal subcommand is found, we try to exec an external Zas subcommand (plugin).
+	// No internal subcommand matched; try to exec an external Zas subcommand (plugin).
+	return runPlugin(args)
+}
+
+func runPlugin(args []string) int {
 	cmd := exec.Command(fmt.Sprintf("%s%s", zas.ZAS_PREFIX, args[0]), args[1:]...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	if err := cmd.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "# %s %s\n", args[0], strings.Join(args[1:], " "))
-
-		panic(err)
+	err := cmd.Run()
+	if err == nil {
+		return 0
 	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+
+	if errors.Is(err, exec.ErrNotFound) {
+		fmt.Fprintf(os.Stderr, "unknown command: %q\n", args[0])
+	} else {
+		fmt.Fprintf(os.Stderr, "fatal: %s\n", err)
+	}
+	return 127
 }

--- a/cmd/zas/main_test.go
+++ b/cmd/zas/main_test.go
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2013 Dario Castañé.
+ * This file is part of Zas.
+ *
+ * Zas is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Zas is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Zas.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeStubPlugin(t *testing.T, dir, name, script string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+script+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestRunUnknownCommandDoesNotPanic covers the everyday typo case: no
+// zs<name> binary exists on PATH at all. run must report a clean message
+// and a defined exit code instead of the panic/stack trace this is a
+// regression test for.
+func TestRunUnknownCommandDoesNotPanic(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+
+	code := run([]string{"thisdoesnotexist12345"})
+
+	os.Stderr = origStderr
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if code != 127 {
+		t.Errorf("run() = %d, want 127", code)
+	}
+	msg := string(out)
+	if !strings.Contains(msg, "unknown command") || !strings.Contains(msg, "thisdoesnotexist12345") {
+		t.Errorf("stderr = %q, want it to report the unknown command", msg)
+	}
+	if strings.Contains(msg, "panic") || strings.Contains(msg, "goroutine") {
+		t.Errorf("stderr = %q, want no panic/stack trace", msg)
+	}
+}
+
+// TestRunPluginExitCodePropagates covers a plugin that starts but exits
+// non-zero: its exact exit code must reach the caller, not a panic.
+func TestRunPluginExitCodePropagates(t *testing.T) {
+	dir := t.TempDir()
+	writeStubPlugin(t, dir, "zsstubfail", "exit 42")
+	t.Setenv("PATH", dir)
+
+	if code := run([]string{"stubfail"}); code != 42 {
+		t.Errorf("run() = %d, want 42", code)
+	}
+}
+
+// TestRunPluginSuccess is the regression check that a well-behaved plugin
+// still works normally after the error-handling changes.
+func TestRunPluginSuccess(t *testing.T) {
+	dir := t.TempDir()
+	writeStubPlugin(t, dir, "zsstubok", "exit 0")
+	t.Setenv("PATH", dir)
+
+	if code := run([]string{"stubok"}); code != 0 {
+		t.Errorf("run() = %d, want 0", code)
+	}
+}
+
+// TestRunUnknownFlagOnInternalSubcommand is a narrow regression check that
+// the unrelated cmd.Flag.Parse usage-error path (exit 2), left untouched by
+// this fix, still works after extracting run out of main.
+func TestRunUnknownFlagOnInternalSubcommand(t *testing.T) {
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = devNull.Close() }()
+
+	origStderr := os.Stderr
+	os.Stderr = devNull
+	defer func() { os.Stderr = origStderr }()
+
+	if code := run([]string{"generate", "--no-such-flag"}); code != 2 {
+		t.Errorf("run() = %d, want 2", code)
+	}
+}


### PR DESCRIPTION
## Summary
- The external-plugin dispatch tail in `main()` handled two distinct failure modes the same way: `panic(err)`, printing a raw Go stack trace and discarding whatever exit code a plugin itself reported.
- `cmd.Run()`'s error is now inspected with `errors.As`/`errors.Is`: a genuine `*exec.ExitError` propagates its exact exit code; a lookup failure (the common typo case, e.g. `zas gnerate`) prints a clean `unknown command: "..."` message and exits 127 (the traditional Unix "command not found" code, kept distinct from this file's existing usage-error exit 2 and internal-failure exit 1); any other exec-start failure falls back to the same `fatal: %s` wording already used elsewhere in this file.
- `main`'s dispatch body is extracted into `run(args []string) int` (with the external-exec tail split into its own `runPlugin`), so this is unit-testable in-process without a subprocess; `main` is now just `os.Exit(run(os.Args[1:]))`. `cmd/zas` gains its first tests.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` — clean
- [x] `go test ./... -race` — clean, including four new `cmd/zas` tests (unknown command, plugin exit-code propagation, successful plugin, existing flag-parse usage error unaffected)
- [x] Manually verified both fixed behaviors against the built binary: an unknown command prints a clean message and exits 127 (no panic); a stub plugin exiting 42 causes `zas` to exit exactly 42