### PR TITLE
fix(generate): bound the renderAsync goroutine fan-out with a pool

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -29,8 +29,10 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	ttext "text/template"
 	"time"
 
@@ -129,9 +131,28 @@ type Generator struct {
 
 	wg sync.WaitGroup
 
+	// sem bounds how many renderAsync goroutines may run at once (see
+	// renderConcurrency), so a large site doesn't fan out one goroutine
+	// per source file with no ceiling. Lazily sized on first use in walk,
+	// whose own invocations are sequential like claimedOutputs and
+	// reapedDirs below, so no mutex guards the initialization itself.
+	sem chan struct{}
+
+	// active and peakActive track how many renderAsync goroutines are
+	// concurrently doing real rendering work. Nothing in production code
+	// reads peakActive; it exists purely so tests can assert the bound
+	// enforced by sem is actually respected.
+	active     atomic.Int64
+	peakActive atomic.Int64
+
 	// Guards errs, which collects per-file render errors from renderAsync goroutines.
 	mu   sync.Mutex
 	errs []error
+
+	// printMu serializes stdout writes from renderAsync goroutines (the
+	// verbose "+" line in walk and the error lines in render) so
+	// concurrent goroutines can't interleave mid-line.
+	printMu sync.Mutex
 
 	// reapedDirs holds deploy paths reaper has RemoveAll'd during the
 	// current reap walk. The reap walk is single-threaded, so no mutex.
@@ -144,6 +165,26 @@ type Generator struct {
 	// touched from walk, whose own invocations are sequential, so no
 	// mutex is needed.
 	claimedOutputs map[string]string
+}
+
+// renderConcurrency bounds how many renderAsync goroutines may run at
+// once. Each one interleaves CPU-bound work (HTML5 parse, template
+// execution) with blocking file I/O (reading the source, then an atomic
+// write via temp-file-then-rename), so sizing purely on GOMAXPROCS would
+// leave CPUs idle while goroutines wait on I/O; the x4 multiplier keeps
+// them busy without still spawning thousands of concurrent goroutines
+// (and open file descriptors) for a large site.
+func renderConcurrency() int {
+	return runtime.GOMAXPROCS(0) * 4
+}
+
+// printLine writes args to stdout like fmt.Println, but serialized
+// against every other printLine call so concurrent renderAsync
+// goroutines (and walk itself) never interleave mid-line.
+func (gen *Generator) printLine(args ...interface{}) {
+	gen.printMu.Lock()
+	defer gen.printMu.Unlock()
+	fmt.Println(args...)
 }
 
 /*
@@ -391,9 +432,16 @@ func (gen *Generator) walk(path string, info os.FileInfo, err error) (ierr error
 		}
 		gen.claimedOutputs[outputPath] = path
 		if gen.Verbose {
-			fmt.Println("+", path)
+			gen.printLine("+", path)
+		}
+		if gen.sem == nil {
+			gen.sem = make(chan struct{}, renderConcurrency())
 		}
 		gen.wg.Add(1)
+		// Blocks once renderConcurrency() goroutines are already in
+		// flight, throttling walk itself until one finishes and releases
+		// its slot - the actual fan-out cap.
+		gen.sem <- struct{}{}
 		go gen.renderAsync(path)
 	}
 	return
@@ -402,6 +450,16 @@ func (gen *Generator) walk(path string, info os.FileInfo, err error) (ierr error
 func (gen *Generator) renderAsync(path string) {
 	var err error
 	defer gen.wg.Done()
+	defer func() { <-gen.sem }()
+
+	n := gen.active.Add(1)
+	defer gen.active.Add(-1)
+	for {
+		peak := gen.peakActive.Load()
+		if n <= peak || gen.peakActive.CompareAndSwap(peak, n) {
+			break
+		}
+	}
 
 	switch {
 	case strings.HasSuffix(path, ".md"):
@@ -621,13 +679,13 @@ func (gen *Generator) render(path string, input []byte) (err error) {
 	}
 	doc, err := gen.parseAndReplace(processed, &data)
 	if err != nil {
-		fmt.Println(err)
+		gen.printLine(err)
 		return
 	}
 	gen.cleanUnnecessaryPTags(doc)
 	data.Page, err = gen.extractPageConfig(doc)
 	if err != nil {
-		fmt.Println(path, "=>", err)
+		gen.printLine(path, "=>", err)
 		err = nil
 	}
 	data.FirstTitle = gen.getTitle(doc)

--- a/render_concurrency_test.go
+++ b/render_concurrency_test.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2013 Dario Castañé.
+ * This file is part of Zas.
+ *
+ * Zas is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Zas is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Zas.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package zas
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+// renderConcurrencyFixtureNPages is large enough (many times over any
+// plausible renderConcurrency() cap) that walk keeps every worker slot
+// busy for most of the run, instead of finishing before concurrency ever
+// builds up.
+const renderConcurrencyFixtureNPages = 800
+
+// TestRenderAsyncConcurrencyIsBounded is the regression test for the
+// unbounded fan-out: walk used to spawn one renderAsync goroutine per
+// source file with no cap at all, so a large site could have thousands of
+// goroutines running at once, each holding open file descriptors and doing
+// a full HTML5 parse/template pass simultaneously. It builds a fixture with
+// hundreds of pages, runs a real Generator.Run, and checks gen.peakActive -
+// incremented/decremented around each renderAsync's real work, purely for
+// this kind of test - never exceeded renderConcurrency()'s cap. That bound
+// is actually structural (sem's capacity limits how many goroutines can
+// ever hold a permit at once, and active/peakActive can't exceed permits
+// held), but this proves it holds for gen.Run() end to end and that real
+// concurrency happens at all (peak > 1), so the test isn't vacuously
+// passing because everything happened to run one at a time.
+func TestRenderAsyncConcurrencyIsBounded(t *testing.T) {
+	newTestSite(t, "walk-error-base")
+
+	must := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := range renderConcurrencyFixtureNPages {
+		name := fmt.Sprintf("page-%04d.md", i)
+		body := fmt.Sprintf("# Page %d\n\n%s\n", i, strings.Repeat("Lorem ipsum dolor sit amet. ", 40))
+		must(os.WriteFile(name, []byte(body), 0o644))
+	}
+
+	gen := &Generator{Full: true}
+	if err := gen.Run(); err != nil {
+		t.Fatalf("Run() error = %v, want nil", err)
+	}
+
+	limit := renderConcurrency()
+	peak := gen.peakActive.Load()
+	if peak > int64(limit) {
+		t.Fatalf("peak concurrent renderAsync goroutines = %d, want <= %d (renderConcurrency cap)", peak, limit)
+	}
+	if peak <= 1 {
+		t.Fatalf("peak concurrent renderAsync goroutines = %d, want > 1 - fixture didn't exercise real concurrency", peak)
+	}
+	t.Logf("peak concurrent renderAsync goroutines = %d (cap %d)", peak, limit)
+
+	// Every page must still have been rendered - the cap must throttle
+	// concurrency, not drop work.
+	for i := range renderConcurrencyFixtureNPages {
+		assertDeployHas(t, fmt.Sprintf("page-%04d.html", i))
+	}
+}


### PR DESCRIPTION
## Summary

- `walk` spawned one `renderAsync` goroutine per source file with no cap at all, so a site with thousands of files could have thousands of goroutines running concurrently, each holding open file descriptors and doing a full HTML5 parse, template execution, and atomic temp-file-then-rename write at once.
- `walk` now acquires a slot from a buffered-channel semaphore before spawning each `renderAsync` goroutine, and `renderAsync` releases it on exit. The semaphore blocks `walk` itself once `renderConcurrency()` goroutines are already in flight, throttling the fan-out instead of letting it grow unbounded.
- Cap is `GOMAXPROCS x4`: rendering interleaves CPU-bound work (parsing, template execution) with blocking file I/O (reads, atomic writes), so a plain `GOMAXPROCS` cap would leave CPUs idle while goroutines wait on I/O. `gen.wg`, `gen.errs`, and the `claimedOutputs`/`sourceIsNewer`/dir-creation logic in `walk` are all unchanged in behavior.
- As a small, naturally-in-scope follow-on: the verbose `+` line in `walk` and the error lines in `render` (both written to stdout from these same goroutines) are now serialized through a small `printLine` helper, so concurrent goroutines can no longer interleave mid-line.
- `golang.org/x/sync` isn't currently a dependency of this module (only a leftover line in `go.sum` from the module graph), so a hand-rolled buffered-channel semaphore was used instead of pulling it in for `errgroup.SetLimit`.

A future config knob to override the concurrency cap may be worth adding later, but a hardcoded default is enough for now.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean) and `golangci-lint run ./...` (0 issues)
- [x] `go test -race -shuffle=on ./...` (full suite green)
- [x] Added `TestRenderAsyncConcurrencyIsBounded`, which builds a fixture with 800 pages, runs a real `Generator.Run`, and asserts the peak number of concurrently-active `renderAsync` goroutines (tracked via an atomic counter used only for this test) never exceeds `renderConcurrency()`'s cap while also confirming genuine concurrency happened (peak > 1) - it observed a peak of exactly 64 (`GOMAXPROCS(0)=16 x4`) on the CI-equivalent dev machine.
- [x] Manually built the `zas` binary and ran `generate` against a 3000-file fixture: completed in ~170ms, all 3000 pages rendered correctly, exit code 0.