### PR TITLE
feat(cmd/zas): add a help command and subcommand usage listing

### DIFF
--- a/cmd/zas/main.go
+++ b/cmd/zas/main.go
@@ -21,9 +21,11 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"runtime"
+	"runtime/debug"
 	"strings"
 
 	"github.com/darccio/zas"
@@ -35,26 +37,46 @@ import (
 var subcommands = []*zas.Subcommand{
 	cmdInit,
 	cmdGenerate,
+	cmdHelp,
+	cmdVersion,
 }
 
 var (
 	verbose, full *bool
-	cmdInit       = zas.NewSubcommand("init", func() error {
+	cmdInit       = zas.NewSubcommand("init - create a new Zas site in the current directory", func() error {
 		i := zas.Init{}
 		return i.Run()
 	})
-	cmdGenerate = zas.NewSubcommand("generate", func() error {
+	cmdGenerate = zas.NewSubcommand("generate - render the site from source into the deploy directory", func() error {
 		g := zas.Generator{
 			Verbose: *verbose,
 			Full:    *full,
 		}
 		return g.Run()
 	})
+	// cmdHelp and cmdVersion get their Run funcs wired up in init() below,
+	// rather than inline here: both printUsage and printVersion end up
+	// referring back to the subcommands slice (to list every command's
+	// UsageLine), and subcommands' own initializer lists cmdHelp and
+	// cmdVersion. Wiring Run inline would make that an initialization
+	// cycle; init() runs after all package-level vars are set up, so
+	// assigning it there does not.
+	cmdHelp    = zas.NewSubcommand("help - show this help message, or run \"zas <command> -h\" for a command's flags", nil)
+	cmdVersion = zas.NewSubcommand("version - print zas version information", nil)
 )
 
 func init() {
 	verbose = cmdGenerate.Flag.Bool("verbose", false, "Verbose output")
 	full = cmdGenerate.Flag.Bool("full", false, "Full generation (non-incremental mode)")
+
+	cmdHelp.Run = func() error {
+		printUsage(os.Stdout)
+		return nil
+	}
+	cmdVersion.Run = func() error {
+		printVersion(os.Stdout)
+		return nil
+	}
 }
 
 func main() {
@@ -69,8 +91,17 @@ func run(args []string) int {
 	}
 
 	if strings.HasPrefix(args[0], "-") {
-		// If the first argument is a flag, we default to "generate".
-		args = append([]string{"generate"}, args...)
+		switch args[0] {
+		case "-h", "-help", "--help":
+			// Top-level help beats the "defaults to generate" rule below:
+			// show general help instead of generate's own -h usage.
+			args = append([]string{cmdHelp.Name}, args[1:]...)
+		case "-version", "--version":
+			args = append([]string{cmdVersion.Name}, args[1:]...)
+		default:
+			// If the first argument is a flag, we default to "generate".
+			args = append([]string{"generate"}, args...)
+		}
 	}
 
 	command := strings.ToLower(args[0])
@@ -118,4 +149,61 @@ func runPlugin(args []string) int {
 		fmt.Fprintf(os.Stderr, "fatal: %s\n", err)
 	}
 	return 127
+}
+
+// printUsage writes the top-level help text: what zas is, how to invoke it,
+// and the list of internal subcommands with their one-line usage.
+func printUsage(w io.Writer) {
+	_, _ = fmt.Fprintf(w, "%s is a static site generator.\n\n", zas.ZAS_NAME)
+	_, _ = fmt.Fprintf(w, "Usage:\n\n\t%s <command> [arguments]\n\n", zas.ZAS)
+	_, _ = fmt.Fprintln(w, "The commands are:")
+	_, _ = fmt.Fprintln(w)
+	for _, cmd := range subcommands {
+		_, _ = fmt.Fprintf(w, "\t%s\n", cmd.UsageLine)
+	}
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintf(w, "Run \"%s <command> -h\" for a command's own flags, or \"%s version\" for version information.\n", zas.ZAS, zas.ZAS)
+}
+
+// printVersion writes a best-effort version string for the zas binary,
+// derived from Go's module and VCS build-info stamping (runtime/debug,
+// available since Go 1.18). For a binary built with "go install
+// .../cmd/zas@<version>" this reports that module version; for a plain "go
+// build" inside a checkout it typically reports "(devel)" plus the VCS
+// revision it was built from.
+func printVersion(w io.Writer) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		_, _ = fmt.Fprintf(w, "%s version unknown (no build info available)\n", zas.ZAS)
+		return
+	}
+
+	version := info.Main.Version
+	if version == "" {
+		version = "(devel)"
+	}
+
+	var revision string
+	var dirty bool
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			revision = setting.Value
+		case "vcs.modified":
+			dirty = setting.Value == "true"
+		}
+	}
+
+	_, _ = fmt.Fprintf(w, "%s version %s", zas.ZAS, version)
+	if revision != "" {
+		if len(revision) > 12 {
+			revision = revision[:12]
+		}
+		_, _ = fmt.Fprintf(w, " (%s", revision)
+		if dirty {
+			_, _ = fmt.Fprint(w, "-dirty")
+		}
+		_, _ = fmt.Fprint(w, ")")
+	}
+	_, _ = fmt.Fprintf(w, " %s\n", info.GoVersion)
 }

--- a/cmd/zas/main_test.go
+++ b/cmd/zas/main_test.go
@@ -33,6 +33,31 @@ func writeStubPlugin(t *testing.T, dir, name, script string) {
 	}
 }
 
+// captureOutput redirects *target (os.Stdout or os.Stderr) to a pipe for
+// the duration of fn, and returns everything written to it.
+func captureOutput(t *testing.T, target **os.File, fn func()) string {
+	t.Helper()
+
+	orig := *target
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	*target = w
+
+	fn()
+
+	*target = orig
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
+}
+
 // TestRunUnknownCommandDoesNotPanic covers the everyday typo case: no
 // zs<name> binary exists on PATH at all. run must report a clean message
 // and a defined exit code instead of the panic/stack trace this is a
@@ -110,5 +135,93 @@ func TestRunUnknownFlagOnInternalSubcommand(t *testing.T) {
 
 	if code := run([]string{"generate", "--no-such-flag"}); code != 2 {
 		t.Errorf("run() = %d, want 2", code)
+	}
+}
+
+// TestRunHelpListsSubcommands covers "zas help": it must succeed and list
+// every internal subcommand's one-line usage, instead of falling through to
+// runPlugin looking for a nonexistent "zshelp" binary.
+func TestRunHelpListsSubcommands(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	var code int
+	out := captureOutput(t, &os.Stdout, func() {
+		code = run([]string{"help"})
+	})
+
+	if code != 0 {
+		t.Errorf("run() = %d, want 0", code)
+	}
+	for _, name := range []string{"init", "generate", "help", "version"} {
+		if !strings.Contains(out, name) {
+			t.Errorf("stdout = %q, want it to mention subcommand %q", out, name)
+		}
+	}
+}
+
+// TestRunTopLevelHelpFlag covers "zas -h" and "zas --help" used bare (no
+// other subcommand): both must now show the same general help as "zas
+// help", not the old behavior of being rewritten to "generate -h".
+func TestRunTopLevelHelpFlag(t *testing.T) {
+	for _, arg := range []string{"-h", "-help", "--help"} {
+		t.Run(arg, func(t *testing.T) {
+			t.Setenv("PATH", t.TempDir())
+
+			var code int
+			out := captureOutput(t, &os.Stdout, func() {
+				code = run([]string{arg})
+			})
+
+			if code != 0 {
+				t.Errorf("run() = %d, want 0", code)
+			}
+			// The general help lists every subcommand's usage line,
+			// including "version" - generate's own -h usage would not.
+			if !strings.Contains(out, "version") {
+				t.Errorf("stdout = %q, want general help mentioning the version subcommand", out)
+			}
+		})
+	}
+}
+
+// TestRunGenerateHelpStillShowsGenerateUsage is the regression guard for the
+// routing change above: "zas generate -h" (subcommand named explicitly)
+// must keep showing generate's own flag usage, not the general help.
+func TestRunGenerateHelpStillShowsGenerateUsage(t *testing.T) {
+	var code int
+	// flag.FlagSet's default usage output goes to its Output(), which
+	// defaults to os.Stderr.
+	out := captureOutput(t, &os.Stderr, func() {
+		code = run([]string{"generate", "-h"})
+	})
+
+	if code != 0 {
+		t.Errorf("run() = %d, want 0", code)
+	}
+	if !strings.Contains(out, "Usage of generate:") {
+		t.Errorf("stderr = %q, want it to report \"Usage of generate:\" (not \"Usage of :\")", out)
+	}
+	if !strings.Contains(out, "-verbose") || !strings.Contains(out, "-full") {
+		t.Errorf("stderr = %q, want it to list generate's -verbose and -full flags", out)
+	}
+}
+
+// TestRunVersion covers "zas version" and the top-level "-version"/
+// "--version" flags: all three must print version information and exit 0.
+func TestRunVersion(t *testing.T) {
+	for _, args := range [][]string{{"version"}, {"-version"}, {"--version"}} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var code int
+			out := captureOutput(t, &os.Stdout, func() {
+				code = run(args)
+			})
+
+			if code != 0 {
+				t.Errorf("run() = %d, want 0", code)
+			}
+			if !strings.Contains(out, "zas version") {
+				t.Errorf("stdout = %q, want it to report a zas version", out)
+			}
+		})
 	}
 }

--- a/subcommand.go
+++ b/subcommand.go
@@ -43,9 +43,27 @@ type Subcommand struct {
 // NewSubcommand builds a Subcommand from a usage line and its run function.
 func NewSubcommand(usageLine string, run func() error) *Subcommand {
 	data := strings.SplitN(usageLine, " ", 2)
+	name := strings.ToLower(data[0])
+
+	// Named (rather than the zero value) so that Go's own flag-parsing
+	// error/usage output - e.g. from an unrecognized flag, or -h/-help on a
+	// subcommand with no Usage func set - reports "Usage of <name>:"
+	// instead of "Usage of :".
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	// flag.NewFlagSet points fs.Usage at fs.defaultUsage, a method value
+	// bound to the *flag.FlagSet it returns. Subcommand.Flag stores a
+	// flag.FlagSet by value, so fs gets copied below; a bound Usage would
+	// keep referring to this now-orphaned fs instead of the copy that
+	// callers actually register flags on and parse with, so it would
+	// print an empty flag list. Clearing it here restores the ordinary
+	// (nil-Usage) behavior, where usage() calls defaultUsage() on
+	// whichever FlagSet it's actually invoked on.
+	fs.Usage = nil
+
 	return &Subcommand{
 		UsageLine: usageLine,
-		Name:      strings.ToLower(data[0]),
+		Name:      name,
 		Run:       run,
+		Flag:      *fs,
 	}
 }


### PR DESCRIPTION
## Summary

zas had no help/usage/version surface: no `zas help`, no version output, and a bare `zas -h`/`--help` silently got rewritten to `generate -h` instead of showing anything general.

- `zas help` (and top-level `zas -h`/`-help`/`--help`) now print a short description of zas plus every subcommand's one-line usage, pulled from the existing (previously unused) `Subcommand.UsageLine` field.
- `zas version` (and top-level `zas -version`/`--version`) print version information derived from `runtime/debug.ReadBuildInfo()` — the module version and VCS revision, with no extra build tooling required. It works out of the box for `go install .../cmd/zas@version` installs.
- `help` and `version` are ordinary entries in the existing `subcommands` dispatch table, alongside `init` and `generate`, reusing the existing dispatch loop rather than adding a special case.
- `zas generate -h` is unaffected and still shows generate's own `-verbose`/`-full` flags — routing only changes for the bare top-level flag, not a named subcommand.
- `Subcommand`'s `flag.FlagSet` is now constructed via `flag.NewFlagSet(name, ...)` instead of the zero value, so Go's own flag-parsing usage output (e.g. an unrecognized flag, or `-h` on a subcommand with no custom `Usage` func) reads `Usage of <name>:` instead of `Usage of :`.
- Along the way, found and fixed a subtler stdlib interaction: `flag.NewFlagSet` binds `FlagSet.Usage` to a method value on the FlagSet it returns, which silently breaks once that FlagSet is copied by value into `Subcommand.Flag` (the copy's registered flags go unlisted, since the bound `Usage` still points at the original, flag-less instance). Fixed by clearing `Usage` after copying, restoring the ordinary dynamically-dispatched `defaultUsage()` behavior.

Out of scope (deliberately untouched): `runtime.GOMAXPROCS`, internal-vs-external dispatch casing, positional-argument validation, stdin wiring to plugins.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .`, `golangci-lint run ./...` all clean
- [x] `go test -race -count=1 ./...` passes, including new tests in `cmd/zas/main_test.go`:
  - `TestRunHelpListsSubcommands`
  - `TestRunTopLevelHelpFlag` (`-h`, `-help`, `--help`)
  - `TestRunGenerateHelpStillShowsGenerateUsage` (regression guard)
  - `TestRunVersion` (`version`, `-version`, `--version`)
- [x] Built the binary and ran live: `zas help`, `zas -h`, `zas --help`, `zas version`, `zas -version`, `zas --version`, `zas generate -h`, `zas init -h`, `zas nosuchcmd` (still 127) — all behave as expected