### PR TITLE
chore(cmd/zas): remove no-op GOMAXPROCS call

### DIFF
--- a/cmd/zas/main.go
+++ b/cmd/zas/main.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"runtime"
 	"runtime/debug"
 	"strings"
 
@@ -80,7 +79,6 @@ func init() {
 }
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	os.Exit(run(os.Args[1:]))
 }
 


### PR DESCRIPTION
## Summary

- `main()` called `runtime.GOMAXPROCS(runtime.NumCPU())` on startup. This has been the runtime's own default since Go 1.5 (2015), so the call changes nothing — dead boilerplate from the project's 2013 origin.
- Removed the call and the now-unused `"runtime"` import (`runtime/debug`, used elsewhere for version reporting, is a separate import and is untouched).

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` (clean), `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./...` (full existing suite green)