### PR TITLE
fix(cmd/zas): close three gaps in subcommand dispatch

### DIFF
--- a/cmd/zas/main.go
+++ b/cmd/zas/main.go
@@ -113,6 +113,15 @@ func run(args []string) int {
 				return 2
 			}
 
+			// Anything left over after flag parsing is a positional
+			// argument none of the internal subcommands accept; silently
+			// discarding it would let typos and misplaced arguments through
+			// unnoticed, so treat it the same as a flag.Parse usage error.
+			if extra := cmd.Flag.Args(); len(extra) > 0 {
+				fmt.Fprintf(os.Stderr, "%s: unexpected argument(s): %s\n", cmd.Name, strings.Join(extra, " "))
+				return 2
+			}
+
 			if err := cmd.Run(); err != nil {
 				fmt.Fprintf(os.Stderr, "fatal: %s\n", err)
 				return 1
@@ -122,12 +131,17 @@ func run(args []string) int {
 		}
 	}
 
-	// No internal subcommand matched; try to exec an external Zas subcommand (plugin).
-	return runPlugin(args)
+	// No internal subcommand matched; try to exec an external Zas subcommand
+	// (plugin). command is already the lower-cased form of args[0] (see
+	// above), so plugin lookup is case-insensitive the same way internal
+	// dispatch is: "zas Hello", "zas HELLO", and "zas hello" all resolve to
+	// the same zs<name> binary on PATH.
+	return runPlugin(append([]string{command}, args[1:]...))
 }
 
 func runPlugin(args []string) int {
 	cmd := exec.Command(fmt.Sprintf("%s%s", zas.ZAS_PREFIX, args[0]), args[1:]...)
+	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/cmd/zas/main_test.go
+++ b/cmd/zas/main_test.go
@@ -225,3 +225,115 @@ func TestRunVersion(t *testing.T) {
 		})
 	}
 }
+
+// TestRunPluginDispatchIsCaseInsensitive covers the casing-consistency fix:
+// internal dispatch already lower-cases args[0] before matching against the
+// subcommands table, so plugin dispatch must fold the command name the same
+// way before looking for a zs<name> binary. Without the fix, only the
+// all-lowercase spelling would find the (lowercase-named) stub binary; the
+// mixed- and upper-case spellings would fail with "unknown command" even
+// though the same plugin is unambiguously being asked for.
+func TestRunPluginDispatchIsCaseInsensitive(t *testing.T) {
+	dir := t.TempDir()
+	writeStubPlugin(t, dir, "zsstubcase", "exit 0")
+	t.Setenv("PATH", dir)
+
+	for _, arg := range []string{"stubcase", "StubCase", "STUBCASE"} {
+		t.Run(arg, func(t *testing.T) {
+			if code := run([]string{arg}); code != 0 {
+				t.Errorf("run([]string{%q}) = %d, want 0", arg, code)
+			}
+		})
+	}
+}
+
+// TestRunUnexpectedPositionalArgumentRejected covers the fix for silently
+// dropped positional arguments: leftover non-flag arguments after
+// cmd.Flag.Parse are now a usage error (stderr message, exit code 2 - the
+// same code flag.Parse itself uses for a bad flag) instead of being
+// discarded. init and generate both take no positional arguments in their
+// own logic, so both must reject one identically rather than special-casing
+// either.
+func TestRunUnexpectedPositionalArgumentRejected(t *testing.T) {
+	for _, args := range [][]string{
+		{"generate", "-verbose", "some-unexpected-argument"},
+		{"init", "some-unexpected-argument"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var code int
+			out := captureOutput(t, &os.Stderr, func() {
+				code = run(args)
+			})
+
+			if code != 2 {
+				t.Errorf("run(%v) = %d, want 2", args, code)
+			}
+			if !strings.Contains(out, "some-unexpected-argument") {
+				t.Errorf("stderr = %q, want it to mention the unexpected argument", out)
+			}
+		})
+	}
+}
+
+// TestRunHelpRejectsUnexpectedArgument is the symmetry check for the fix
+// above: help and version route through the exact same dispatch loop as
+// init and generate, so an unexpected positional argument must be rejected
+// there too, rather than being silently accepted by some subcommands and
+// rejected by others.
+func TestRunHelpRejectsUnexpectedArgument(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	var code int
+	out := captureOutput(t, &os.Stderr, func() {
+		code = run([]string{"help", "some-unexpected-argument"})
+	})
+
+	if code != 2 {
+		t.Errorf("run() = %d, want 2", code)
+	}
+	if !strings.Contains(out, "some-unexpected-argument") {
+		t.Errorf("stderr = %q, want it to mention the unexpected argument", out)
+	}
+}
+
+// TestRunPluginReceivesStdin covers the stdin fix: runPlugin previously
+// wired the plugin subprocess's stdout and stderr but not its stdin, so a
+// filter-style plugin reading piped input would see immediate EOF. The stub
+// here is a "cat", which echoes back whatever it reads from stdin; if the
+// fix works, that content shows up on zas's own stdout.
+func TestRunPluginReceivesStdin(t *testing.T) {
+	dir := t.TempDir()
+	writeStubPlugin(t, dir, "zsstubecho", "cat")
+	// Unlike the other stub-plugin tests, PATH keeps the real system
+	// directories (after dir, so the stub still wins on name collisions):
+	// the stub script itself execs the real "cat" binary to copy stdin to
+	// stdout, so it needs "cat" to be findable too.
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	origStdin := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = r.Close() }()
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
+	const piped = "some piped input"
+	go func() {
+		_, _ = w.WriteString(piped)
+		_ = w.Close()
+	}()
+
+	var code int
+	out := captureOutput(t, &os.Stdout, func() {
+		code = run([]string{"stubecho"})
+	})
+
+	if code != 0 {
+		t.Errorf("run() = %d, want 0", code)
+	}
+	if !strings.Contains(out, piped) {
+		t.Errorf("stdout = %q, want it to contain the piped stdin content %q", out, piped)
+	}
+}


### PR DESCRIPTION
## Summary

- Plugin dispatch now resolves the command name case-insensitively, the same way internal subcommand lookup already does, so `zas Hello`/`zas HELLO`/`zas hello` all resolve to the same `zshello` binary instead of only the exact-case spelling working.
- Leftover positional arguments after flag parsing (e.g. `zas generate -verbose some-typo`) are now a usage error (message on stderr, exit code 2 — the same code an actual flag-parse failure already uses) instead of being silently discarded. This applies uniformly to every subcommand routed through the shared dispatch loop (`init`, `generate`, `help`, `version`).
- `runPlugin` now wires the plugin subprocess's stdin (it already wired stdout/stderr), so filter-style plugins that read piped input no longer see an immediate EOF.

## Design decisions

**Casing**: extended plugin dispatch to use the already-lower-cased command name rather than making internal dispatch case-sensitive. This is the smaller, less surprising change — it keeps the case-insensitivity behavior internal subcommands already have and simply applies the same rule everywhere, rather than removing existing behavior.

**Positional arguments**: rejected as a usage error at the shared dispatch-loop level (not per-subcommand), reusing the exit code already used for `flag.Parse` errors. `init` and `generate` both take no positional arguments in their own logic and are now rejected identically; `help`/`version` go through the same loop and get the same treatment for consistency, with a test verifying this doesn't disturb their existing (argument-free) paths.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./...` (all green, including new cases: case-insensitive plugin dispatch, unexpected positional argument rejected for `generate`/`init`/`help`, and piped stdin reaching a stub plugin)
- [x] Manual repro with a built binary: `zas hello` / `zas Hello` / `zas HELLO` against a lowercase `zshello` stub all succeed; `zas generate -verbose some-unexpected-argument` and `zas init some-unexpected-argument` both print a stderr message and exit 2 (no side effects); `echo "some input" | zas readstdin` reaches a stub plugin that echoes stdin back