### PR TITLE
fix(generate): reject embed sources that escape the site root

### DIFF
--- a/embed_containment_test.go
+++ b/embed_containment_test.go
@@ -1,0 +1,178 @@
+package zas
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+// <embed src="..."> was read with os.ReadFile(src) and no check that the
+// result stayed inside the site root, so an absolute src or a "../"
+// traversal in site content could pull the contents of any file the build
+// process can read into the published output. resolveEmbedSrc closes that
+// off for all three embed handlers (Markdown, Plain, Html); these tests
+// cover both escape shapes for each handler, and confirm a legitimate
+// embed of a file in a site subdirectory still works.
+
+type embedHandlerCase struct {
+	name    string
+	typ     string
+	relPath string
+	content string
+	call    func(*Generator, *goquery.Selection, *goquery.Document, *ZasData) error
+	want    string
+}
+
+var embedHandlerCases = []embedHandlerCase{
+	{"Markdown", "text/markdown", "note.md", "# Note\n\nHello from markdown.\n", (*Generator).Markdown, "Hello from markdown."},
+	{"Plain", "text/plain", "note.txt", "hello from plain", (*Generator).Plain, "hello from plain"},
+	{"Html", "text/html", "note.html", "<p>hello from html</p>", (*Generator).Html, "hello from html"},
+}
+
+func embedDocFor(t *testing.T, src, typ string) *goquery.Document {
+	t.Helper()
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(
+		`<div><embed src="` + src + `" type="` + typ + `"></div>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return doc
+}
+
+func TestEmbedHandlersRejectAbsolutePathOutsideRoot(t *testing.T) {
+	for _, tc := range embedHandlerCases {
+		t.Run(tc.name, func(t *testing.T) {
+			base := t.TempDir()
+			root := filepath.Join(base, "site")
+			if err := os.Mkdir(root, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			secret := filepath.Join(base, tc.relPath)
+			if err := os.WriteFile(secret, []byte(tc.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			t.Chdir(root)
+
+			doc := embedDocFor(t, secret, tc.typ)
+			gen := &Generator{}
+			err := tc.call(gen, doc.Find("embed"), doc, &ZasData{})
+			if err == nil {
+				t.Fatalf("%s() with an absolute src outside the site root: want error, got nil", tc.name)
+			}
+			if doc.Find("embed").Length() != 1 {
+				t.Fatalf("%s() rejected the embed but still consumed the <embed> tag", tc.name)
+			}
+		})
+	}
+}
+
+func TestEmbedHandlersRejectParentTraversal(t *testing.T) {
+	for _, tc := range embedHandlerCases {
+		t.Run(tc.name, func(t *testing.T) {
+			base := t.TempDir()
+			root := filepath.Join(base, "site")
+			if err := os.Mkdir(root, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(base, tc.relPath), []byte(tc.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			t.Chdir(root)
+
+			traversal := filepath.Join("..", tc.relPath)
+			doc := embedDocFor(t, traversal, tc.typ)
+			gen := &Generator{}
+			err := tc.call(gen, doc.Find("embed"), doc, &ZasData{})
+			if err == nil {
+				t.Fatalf(`%s() with a src escaping the site root via "../": want error, got nil`, tc.name)
+			}
+			if doc.Find("embed").Length() != 1 {
+				t.Fatalf("%s() rejected the embed but still consumed the <embed> tag", tc.name)
+			}
+		})
+	}
+}
+
+func TestEmbedHandlersAllowNestedSubdirectory(t *testing.T) {
+	for _, tc := range embedHandlerCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+			if err := os.Mkdir("partials", 0o755); err != nil {
+				t.Fatal(err)
+			}
+			relPath := filepath.Join("partials", tc.relPath)
+			if err := os.WriteFile(relPath, []byte(tc.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			doc := embedDocFor(t, relPath, tc.typ)
+			gen := &Generator{}
+			if err := tc.call(gen, doc.Find("embed"), doc, &ZasData{}); err != nil {
+				t.Fatalf("%s() for a file in a site subdirectory: error = %v, want nil", tc.name, err)
+			}
+			if got := doc.Find("div").Text(); !strings.Contains(got, tc.want) {
+				t.Fatalf("%s() output = %q, want it to contain %q", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGenerateRejectsEmbedEscapingSiteRootViaAbsolutePath and
+// TestGenerateRejectsEmbedEscapingSiteRootViaTraversal drive the full
+// Generator.Run pipeline (as opposed to calling a handler method
+// directly) to confirm a rejected embed surfaces as an ordinary per-file
+// generation error - the same path any other render failure already takes
+// - rather than a panic or a silent success with leaked file content in
+// the deploy output.
+
+func TestGenerateRejectsEmbedEscapingSiteRootViaAbsolutePath(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "site")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	copyFixture(t, "site", root)
+	t.Chdir(root)
+	saveGlobals(t)
+
+	secret := filepath.Join(base, "secret.txt")
+	if err := os.WriteFile(secret, []byte("do not leak"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	leak := `<embed src="` + secret + `" type="text/plain">` + "\n"
+	if err := os.WriteFile("leak.html", []byte(leak), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := generate(t); err == nil {
+		t.Fatal("generate() with a page embedding an absolute path outside the site root: want error, got nil")
+	}
+	assertDeployMissing(t, "leak.html")
+}
+
+func TestGenerateRejectsEmbedEscapingSiteRootViaTraversal(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "site")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	copyFixture(t, "site", root)
+	t.Chdir(root)
+	saveGlobals(t)
+
+	if err := os.WriteFile(filepath.Join(base, "secret.txt"), []byte("do not leak"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	leak := `<embed src="../secret.txt" type="text/plain">` + "\n"
+	if err := os.WriteFile("leak.html", []byte(leak), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := generate(t); err == nil {
+		t.Fatal(`generate() with a page embedding "../secret.txt": want error, got nil`)
+	}
+	assertDeployMissing(t, "leak.html")
+}

--- a/generate.go
+++ b/generate.go
@@ -770,10 +770,40 @@ func (gen *Generator) copy(dstPath, srcPath string) (err error) {
 	})
 }
 
+// resolveEmbedSrc resolves an <embed src="..."> attribute to an absolute
+// path and rejects any result that falls outside the site root - the
+// process's current directory, the same base every embed src is already
+// read relative to (see walk's use of "." and BuildDeployPath). Without
+// this check, an absolute src or a "../" traversal in site content lets a
+// page pull the contents of any file the build process can read into the
+// published output.
+func (gen *Generator) resolveEmbedSrc(src string) (string, error) {
+	root, err := filepath.Abs(".")
+	if err != nil {
+		return "", err
+	}
+	target, err := filepath.Abs(src)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("embed src %q escapes the site root", src)
+	}
+	return target, nil
+}
+
 // Markdown embeds a Markdown file.
 func (gen *Generator) Markdown(e *goquery.Selection, _ *goquery.Document, data *ZasData) (err error) {
 	if src, ok := e.Attr(atom.Src.String()); ok {
-		mdInput, err := os.ReadFile(src)
+		resolved, err := gen.resolveEmbedSrc(src)
+		if err != nil {
+			return err
+		}
+		mdInput, err := os.ReadFile(resolved)
 		if err != nil {
 			return err
 		}
@@ -793,19 +823,23 @@ func (gen *Generator) Markdown(e *goquery.Selection, _ *goquery.Document, data *
 // Plain embeds a plain text file.
 func (gen *Generator) Plain(e *goquery.Selection, _ *goquery.Document, data *ZasData) (err error) {
 	if src, ok := e.Attr(atom.Src.String()); ok {
+		resolved, err := gen.resolveEmbedSrc(src)
+		if err != nil {
+			return err
+		}
 		var input []byte
-		input, err = os.ReadFile(src)
+		input, err = os.ReadFile(resolved)
 		if err != nil {
 			return err
 		}
 		var template *ttext.Template
 		template, err = ttext.New("current").Parse(string(input))
 		if err != nil {
-			return
+			return err
 		}
 		var processed bytes.Buffer
 		if err = template.Execute(&processed, data); err != nil {
-			return
+			return err
 		}
 		e.ReplaceWithNodes(&html5.Node{Type: html5.TextNode, Data: processed.String()})
 	}
@@ -815,15 +849,19 @@ func (gen *Generator) Plain(e *goquery.Selection, _ *goquery.Document, data *Zas
 // Html embeds a HTML file.
 func (gen *Generator) Html(e *goquery.Selection, _ *goquery.Document, data *ZasData) (err error) {
 	if src, ok := e.Attr(atom.Src.String()); ok {
+		resolved, err := gen.resolveEmbedSrc(src)
+		if err != nil {
+			return err
+		}
 		var input []byte
-		input, err = os.ReadFile(src)
+		input, err = os.ReadFile(resolved)
 		if err != nil {
 			return err
 		}
 		var htmlDoc *goquery.Document
 		htmlDoc, err = gen.parseAndReplace(*bytes.NewBuffer(input), data)
 		if err != nil {
-			return
+			return err
 		}
 		e.ReplaceWithSelection(htmlDoc.Children())
 	}


### PR DESCRIPTION
## Summary

- `<embed src="...">` was resolved by passing the attribute straight to `os.ReadFile` in all three embed handlers (`Markdown`, `Plain`, `Html`), with no check that the result stayed inside the site. An absolute path (`/etc/passwd`) or a `../` traversal in a page's `src` could read the contents of any file the build process can see into the published site.
- Adds a shared `resolveEmbedSrc` helper the three handlers now call before reading: it resolves `src` the same way `os.ReadFile` already did (relative to the process's current directory, the implicit site root used elsewhere in this codebase - see `walk`'s use of `"."` and `BuildDeployPath`), then rejects any result that falls outside that root.
- A rejected embed now returns a clear error through the same per-file generation-error path other render failures already use (`renderAsync` -> `recordErr`), instead of silently leaking file content or crashing.
- Out of scope, left untouched: `src` resolution base semantics (still CWD-relative, a separate known issue), `maxEmbedDepth` recursion guard, and the MIME-plugin exec path's own `pluginNameRe` containment (a different attack surface).

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` all clean
- [x] `golangci-lint run ./...` reports 0 issues
- [x] `go test -race -count=1 ./...` passes, including all pre-existing embed/e2e coverage
- [x] New tests in `embed_containment_test.go`:
  - `TestEmbedHandlersRejectAbsolutePathOutsideRoot` - all three handlers reject an absolute `src` outside the root
  - `TestEmbedHandlersRejectParentTraversal` - all three handlers reject a `"../"` traversal
  - `TestEmbedHandlersAllowNestedSubdirectory` - all three handlers still succeed on a legitimate embed in a site subdirectory
  - `TestGenerateRejectsEmbedEscapingSiteRootViaAbsolutePath` / `...ViaTraversal` - full `Generator.Run()` pipeline surfaces the rejection as a normal per-file error, not a panic, and writes nothing to deploy output
  - Confirmed these five tests fail against the pre-fix code and pass after the fix
- [x] Live repro with the built `zas` binary: a page embedding `/etc/hostname` (absolute) and a page embedding `../secret-outside.txt` (traversal) both fail `zas generate` cleanly with `fatal: <file>: embed src "..." escapes the site root` and no deploy output; a legitimate site with `Html`/`Markdown`/`Plain` embeds from a `partials/` subdirectory plus a `sub/` page still generates successfully end to end