### PR TITLE
fix(generate): find the page's config comment past a leading doctype

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -737,15 +737,26 @@ func (gen *Generator) getTitle(doc *goquery.Document) (title string) {
 
 /*
  * Extracts first HTML commend as map. It expects it as a valid YAML map.
+ *
+ * The config comment is looked for among the document's top-level nodes
+ * (Doctype, comments, the <html> element, ...), not just the literal first
+ * one: a leading "<!DOCTYPE html>" - or anything else parsed as a sibling
+ * ahead of the comment - would otherwise push the comment out of the
+ * FirstChild slot and make its config silently disappear. This still stops
+ * at the first CommentNode it finds walking top-level siblings in document
+ * order, so the established "config comment as the very first line" layout
+ * keeps working exactly as before.
  */
 func (gen *Generator) extractPageConfig(doc *goquery.Document) (config map[interface{}]interface{}, err error) {
 	var comment *html5.Node
-	for _, child := range doc.Nodes {
-		if child.FirstChild == nil {
-			continue
+	for _, root := range doc.Nodes {
+		for child := root.FirstChild; child != nil; child = child.NextSibling {
+			if child.Type == html5.CommentNode {
+				comment = child
+				break
+			}
 		}
-		if child.FirstChild.Type == html5.CommentNode {
-			comment = child.FirstChild
+		if comment != nil {
 			break
 		}
 	}

--- a/page_data_test.go
+++ b/page_data_test.go
@@ -64,3 +64,55 @@ func TestRenderPageBodyCanCallPointerReceiverMethod(t *testing.T) {
 		t.Fatalf("deployed output = %q, want it to contain %q", out, want)
 	}
 }
+
+// extractPageConfig used to only look at the document's literal first
+// child, so a leading "<!DOCTYPE html>" (or anything else parsed as a
+// sibling ahead of the comment) pushed the config comment out of that slot
+// and its config was silently dropped - the page fell back to its <h1> text
+// as the title instead of erroring. These two tests render otherwise
+// identical pages, one with a leading doctype and one without, and confirm
+// both pick up the title override from their config comment rather than
+// falling back to the <h1>.
+
+func TestExtractPageConfigFoundAfterLeadingDoctype(t *testing.T) {
+	testExtractPageConfigTitleOverride(t, "<!DOCTYPE html>\n<!-- title: Overridden -->\n<h1>Ignored</h1>")
+}
+
+func TestExtractPageConfigFoundAsFirstLine(t *testing.T) {
+	testExtractPageConfigTitleOverride(t, "<!-- title: Overridden -->\n<h1>Ignored</h1>")
+}
+
+func testExtractPageConfigTitleOverride(t *testing.T, source string) {
+	t.Helper()
+	t.Chdir(t.TempDir())
+	if err := os.MkdirAll("deploy", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gen := &Generator{
+		Config: ConfigSection{
+			"zas": ConfigSection{"deploy": "deploy"},
+		},
+		I18n: &gt.Build{Index: gt.Strings{}, Origin: "en"},
+	}
+	layout, err := thtml.New("layout").Funcs(helpers).Parse(`{{.Title}}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gen.Layout = layout
+
+	if err := gen.render("page.html", []byte(source)); err != nil {
+		t.Fatalf("render() error = %v, want nil", err)
+	}
+
+	out, err := os.ReadFile(filepath.Join("deploy", "page.html"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "Overridden") {
+		t.Fatalf("deployed output = %q, want it to contain the config comment's title %q", got, "Overridden")
+	}
+	if strings.Contains(got, "Ignored") {
+		t.Fatalf("deployed output = %q, want it to not fall back to the <h1> title %q", got, "Ignored")
+	}
+}


### PR DESCRIPTION
## Summary

`extractPageConfig` only ever inspected the document node's literal `FirstChild` for a comment. That happened to work because the existing convention puts a page's config comment as the very first thing in the file, so it usually was the first child. But a standards-compliant `.html` source starting with `<!DOCTYPE html>` parses that doctype into the `FirstChild` slot instead, pushing the actual config comment into `FirstChild.NextSibling` - which was never examined. The page's config was then silently dropped, with the title quietly falling back to the `<h1>` text instead of erroring or warning.

- Walk the document node's top-level siblings (Doctype, comment, `<html>`, ...) via `NextSibling` looking for the first `CommentNode`, instead of only checking `FirstChild`.
- This is a minimal, general fix at the traversal level - it doesn't special-case doctypes, so anything else that could occupy the first-child slot ahead of the comment is handled the same way - while still stopping at the first top-level comment, so the "config comment as the first line" convention keeps working exactly as before.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .`, `golangci-lint run ./...` all clean
- [x] `go test -race -count=1 ./...` passes
- [x] Added `TestExtractPageConfigFoundAfterLeadingDoctype` and `TestExtractPageConfigFoundAsFirstLine` in `page_data_test.go`, rendering otherwise-identical pages (one with a leading doctype, one without) and asserting both pick up the title override from their config comment rather than falling back to the `<h1>`
- [x] Confirmed the new doctype test fails on the pre-fix code (falls back to the `<h1>` text) and passes after the fix
- [x] Built the `zas` binary and ran `zas generate` against a small fixture site with a doctype-first `.html` page carrying a title-override config comment: deployed `<title>` reflects the override, not the `<h1>` fallback. Also confirmed a page using the existing "config comment as first line" convention still works unchanged