### PR TITLE
fix(generate): skip symlinks during generation instead of mishandling them

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -419,6 +419,23 @@ func (gen *Generator) walk(path string, info os.FileInfo, err error) (ierr error
 		}
 		return nil
 	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		// filepath.Walk calls os.Lstat, so a symlinked directory arrives
+		// here with info.IsDir() == false - Lstat reports the link itself,
+		// not its target - which used to fall through to the file branch
+		// below and reach copy(), whose os.Open follows the link and then
+		// fails writing a regular file where a directory belongs. A
+		// symlinked file has the same Lstat shape and used to be copied by
+		// silently dereferencing it, with no indication in the output that
+		// the source was ever a link. Skip both explicitly instead: a
+		// symlinked directory can point anywhere on the filesystem the
+		// build process can read - the same containment concern
+		// resolveEmbedSrc already handles for <embed src> - and following
+		// it would additionally need its own cycle detection, since
+		// filepath.Walk doesn't resolve symlinks on its own.
+		gen.printLine("~", path, "(symlink, not followed)")
+		return nil
+	}
 	if info.IsDir() {
 		ierr = os.MkdirAll(gen.BuildDeployPath(path), os.FileMode(ZAS_DEFAULT_DIR_PERM))
 	} else if gen.sourceIsNewer(path, info) {

--- a/symlink_test.go
+++ b/symlink_test.go
@@ -1,0 +1,148 @@
+package zas
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// filepath.Walk calls os.Lstat, so a symlinked directory reaches walk with
+// info.IsDir() == false (Lstat reports the link itself) and used to fall
+// through to the ordinary file branch, which handed it to copy(). copy()'s
+// os.Open transparently follows the link, and io.Copy then failed writing a
+// regular file where the destination should have been a directory - a
+// confusing "is a directory" error. A symlinked file has the same Lstat
+// shape and used to be copied by silently dereferencing it, with nothing in
+// the deploy output indicating the source was ever a link. These tests
+// confirm both kinds are now skipped explicitly, with a message, instead of
+// either mishandling.
+
+// captureStdout redirects os.Stdout for the duration of fn and returns
+// everything written to it.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	fn()
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = orig
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
+}
+
+func TestWalkSkipsSymlinkedDirectoryWithMessage(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.Mkdir("realdir", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("realdir", "linkdir"); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Lstat("linkdir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gen := &Generator{}
+	var walkErr error
+	out := captureStdout(t, func() {
+		walkErr = gen.walk("linkdir", info, nil)
+	})
+	if walkErr != nil {
+		t.Fatalf("walk(%q) error = %v, want nil", "linkdir", walkErr)
+	}
+	if !strings.Contains(out, "linkdir") || !strings.Contains(out, "symlink") {
+		t.Fatalf("walk(%q) printed %q, want a message mentioning the path and \"symlink\"", "linkdir", out)
+	}
+	gen.wg.Wait()
+	if len(gen.errs) != 0 {
+		t.Fatalf("gen.errs = %v, want none", gen.errs)
+	}
+}
+
+func TestWalkSkipsSymlinkedFileWithMessage(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile("real.txt", []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("real.txt", "link.txt"); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Lstat("link.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gen := &Generator{}
+	var walkErr error
+	out := captureStdout(t, func() {
+		walkErr = gen.walk("link.txt", info, nil)
+	})
+	if walkErr != nil {
+		t.Fatalf("walk(%q) error = %v, want nil", "link.txt", walkErr)
+	}
+	if !strings.Contains(out, "link.txt") || !strings.Contains(out, "symlink") {
+		t.Fatalf("walk(%q) printed %q, want a message mentioning the path and \"symlink\"", "link.txt", out)
+	}
+	gen.wg.Wait()
+	if len(gen.errs) != 0 {
+		t.Fatalf("gen.errs = %v, want none", gen.errs)
+	}
+}
+
+// TestGenerateSkipsSymlinksCleanly drives the full Generator.Run pipeline
+// against a site containing both a directory symlink (realdir/linkdir) and
+// a file symlink (real.txt/link.txt) alongside normal content. Before this
+// fix, the directory symlink made the run fail with a copy error ("is a
+// directory") and the file symlink was silently dereferenced into the
+// deploy output. Now both must be absent from the deploy tree and the rest
+// of the site must generate normally, with no fatal error.
+func TestGenerateSkipsSymlinksCleanly(t *testing.T) {
+	newTestSite(t, "site")
+
+	if err := os.Mkdir("realdir", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join("realdir", "page.md"), []byte("# Real\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("realdir", "linkdir"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile("real.txt", []byte("hello from real"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("real.txt", "link.txt"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := generate(t, fullGen); err != nil {
+		t.Fatalf("generate() with symlinks present: error = %v, want nil (no more \"is a directory\" copy failure)", err)
+	}
+
+	// The symlinks themselves must not appear in deploy output at all -
+	// neither as a mis-copied file (the old directory-symlink failure mode)
+	// nor as a silently dereferenced copy (the old file-symlink failure
+	// mode).
+	assertDeployMissing(t, "linkdir")
+	assertDeployMissing(t, "link.txt")
+
+	// The symlink target reached directly (not through the link) is
+	// unaffected: it's an ordinary source path.
+	assertDeployHas(t, filepath.Join("realdir", "page.html"))
+
+	// Normal content elsewhere in the site still generates fine alongside
+	// the symlinks.
+	assertDeployHas(t, "index.html")
+	assertDeployHas(t, "about.html")
+	assertDeployHas(t, filepath.Join("sub", "page.html"))
+}


### PR DESCRIPTION
## Summary

- filepath.Walk uses os.Lstat, so a symlinked directory reached `walk` with `info.IsDir() == false` (Lstat reports the link itself, not its target) and fell through to the ordinary file branch, which handed it to `copy()`. `copy()`'s `os.Open` transparently follows the link, so `io.Copy` then failed writing a regular file where the destination should have been a directory - a confusing "is a directory" error.
- A symlinked file has the same Lstat shape and was copied by silently dereferencing it, with nothing in the deploy output indicating the source was ever a link.
- `walk` now detects any symlink via `info.Mode()&os.ModeSymlink` and skips it outright (both directory- and file-symlinks), printing a message that names the path so the omission is visible instead of silent.

## Why skip instead of follow

Given this was flagged as low severity, skipping is the proportionate fix: actually following symlinked directories would need manual resolution (`filepath.Walk` doesn't do it natively), cycle/loop detection, and a containment decision for links pointing outside the site root - the same class of concern `resolveEmbedSrc` already closed off for `<embed src>` in a separate, already-merged change. Skipping sidesteps all of that while still giving a clear, correct outcome for both symlink kinds.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `golangci-lint run ./...` - 0 issues
- [x] `go test -race -count=1 ./...` - all passing
- [x] New tests in `symlink_test.go`: unit-level `walk()` tests for a symlinked directory and a symlinked file (confirm no error, no fatal outcome, and a message mentioning the path and "symlink" is printed), plus an end-to-end `Generator.Run()` test (`TestGenerateSkipsSymlinksCleanly`) with `ln -s realdir linkdir` and `ln -s real.txt link.txt` alongside normal content, asserting both are absent from the deploy tree, generation succeeds with no error, and normal content still deploys correctly
- [x] Live repro: built the `zas` binary, created a fixture site with both symlink kinds plus normal markdown content, ran `zas generate -full` - exit code 0, printed `~ link.txt (symlink, not followed)` and `~ linkdir (symlink, not followed)`, no "is a directory" error, `linkdir`/`link.txt` absent from `.zas/deploy`, normal content generated correctly alongside them