### PR TITLE
fix(data): trim trailing slash from baseurl in URL()

### DIFF
--- a/data.go
+++ b/data.go
@@ -73,9 +73,12 @@ func (zd *ZasData) Title() (title string) {
 	return
 }
 
-// URL builds the URL from current configuration.
+// URL builds the URL from current configuration. BaseURL is documented as
+// being configured without a trailing slash, but nothing enforces that; a
+// trailing slash is trimmed here so it doesn't double up with Path, which
+// always starts with its own leading slash.
 func (zd *ZasData) URL() string {
-	return fmt.Sprintf("%s%s", zd.Site.BaseURL, zd.Path)
+	return strings.TrimRight(zd.Site.BaseURL, "/") + zd.Path
 }
 
 // Extra is a helper template method to get any value from ZasData.config

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -87,6 +87,32 @@ func TestIsHomeOK(t *testing.T) {
 	}
 }
 
+// URL used to concatenate BaseURL and Path with no normalization, so a
+// BaseURL configured with a trailing slash (an easy, unenforced mistake -
+// the README says "without final slash" but nothing checks it) produced a
+// double slash where the two met, since Path always starts with its own
+// leading slash.
+
+func TestURLTrimsTrailingSlashFromBaseURL(t *testing.T) {
+	zd := &ZasData{
+		Site: ZasSiteData{BaseURL: "http://example.com/"},
+		Path: "/page.html",
+	}
+	if got, want := zd.URL(), "http://example.com/page.html"; got != want {
+		t.Fatalf("URL() = %q, want %q", got, want)
+	}
+}
+
+func TestURLWithoutTrailingSlashUnchanged(t *testing.T) {
+	zd := &ZasData{
+		Site: ZasSiteData{BaseURL: "http://example.com"},
+		Path: "/page.html",
+	}
+	if got, want := zd.URL(), "http://example.com/page.html"; got != want {
+		t.Fatalf("URL() = %q, want %q", got, want)
+	}
+}
+
 func TestEPropagatesLanguageError(t *testing.T) {
 	zd := &ZasData{
 		Page: map[interface{}]interface{}{"language": 5},


### PR DESCRIPTION
## Summary

`URL()` concatenated `Site.BaseURL` and `Path` with no normalization. `Path` always starts with its own leading slash, so a `baseurl` configured with a trailing slash (an easy, unenforced mistake — the README just says "without final slash") produced a double slash where the two met, e.g. `http://example.com//page.html`.

This trims any trailing slash off `BaseURL` before appending `Path`, so the result is correct regardless of how the user configured `baseurl`.

`IsHome()` was reviewed but left unchanged: `Path` is always built as `"/" + filepath` from an internal relative walk path, so it can never actually be `"//index.html"`. When the resolved language is empty, the `/%s/index.html` branch just degrades to an unreachable comparison — dead but harmless, not a false positive. No real bug there worth touching.

Pretty URLs (eliding `index.html`, e.g. `/about/`) are explicitly out of scope — zas deploys literal `.html` files, so `URL()` producing a path with no corresponding file on disk would just be wrong until the deploy-time output layout itself changes, which is a much bigger, separate decision.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./...` (all green)
- [x] New tests: `TestURLTrimsTrailingSlashFromBaseURL` and `TestURLWithoutTrailingSlashUnchanged` in `resolve_test.go`
- [x] Live repro: built the `zas` binary, generated two fixture sites (one with `baseurl: http://example.com/`, one with `baseurl: http://example.com`) and confirmed `{{.URL}}` renders `http://example.com/index.html` in both cases, with no double slash and no change to the already-correct case