### PR TITLE
fix(generate): stop swallowing directory- and page-config parse errors

### DIFF
--- a/dirconfig_error_test.go
+++ b/dirconfig_error_test.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2013 Dario Castañé.
+ * This file is part of Zas.
+ *
+ * Zas is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Zas is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Zas.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package zas
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// loadZasDirectoryConfig used to discard yaml.Unmarshal's error entirely
+// (_ = yaml.Unmarshal(...)), so a malformed .zas.yml silently produced an
+// empty config with err == nil, which then got memoized for the rest of the
+// run with no diagnostic anywhere. It must now surface that error, exactly
+// once per misconfigured directory thanks to the existing cache.
+
+// malformedDirConfig is invalid YAML: a tab character is not a legal
+// indentation character, so this reliably fails to parse rather than merely
+// producing an unexpected structure.
+const malformedDirConfig = "language: ru\n\tbad: true\n"
+
+func TestLoadZasDirectoryConfigMalformedYAMLSurfacesError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.MkdirAll("sub", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join("sub", ZAS_DIR_CONF_FILE), []byte(malformedDirConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	gen := &Generator{}
+	if _, _, err := gen.loadZasDirectoryConfig(filepath.Join("sub", "page.html")); err == nil {
+		t.Fatal("loadZasDirectoryConfig() with malformed .zas.yml: want error, got nil")
+	} else if wantPath := filepath.Join("sub", ZAS_DIR_CONF_FILE); !strings.Contains(err.Error(), wantPath) {
+		t.Fatalf("error = %v, want it to mention the malformed file's path %q", err, wantPath)
+	}
+	if len(gen.errs) != 1 {
+		t.Fatalf("gen.errs = %v, want exactly one recorded error", gen.errs)
+	}
+
+	// A second call for a different file under the same directory must hit
+	// the cache and NOT re-report the same parse failure a second time.
+	if _, _, err := gen.loadZasDirectoryConfig(filepath.Join("sub", "other.html")); err != nil {
+		t.Fatalf("second loadZasDirectoryConfig() call: error = %v, want nil (cached)", err)
+	}
+	if len(gen.errs) != 1 {
+		t.Fatalf("gen.errs after second call = %v, want still exactly one recorded error (cached, not re-reported)", gen.errs)
+	}
+}
+
+// TestGenerateReportsMalformedDirectoryConfig is the end-to-end regression
+// test: a malformed sub/.zas.yml must fail the overall build (so the
+// mistake can't go unnoticed) while the page under it still renders,
+// falling back to the site-default language instead of quietly and
+// permanently losing sub/'s directory config for the rest of the run.
+func TestGenerateReportsMalformedDirectoryConfig(t *testing.T) {
+	newTestSite(t, "site")
+	if err := os.WriteFile(filepath.Join("sub", ZAS_DIR_CONF_FILE), []byte(malformedDirConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := generate(t)
+	if err == nil {
+		t.Fatal("generate() with a malformed sub/.zas.yml: want error, got nil")
+	}
+	if wantPath := filepath.Join("sub", ZAS_DIR_CONF_FILE); !strings.Contains(err.Error(), wantPath) {
+		t.Fatalf("generate() error = %v, want it to mention %q", err, wantPath)
+	}
+
+	out := readDeploy(t, filepath.Join("sub", "page.html"))
+	if !strings.Contains(out, "Hello") {
+		t.Fatalf("sub/page.html = %q, want it to fall back to the site default language (%q)", out, "Hello")
+	}
+	if strings.Contains(out, "Hola") {
+		t.Fatalf("sub/page.html = %q, want it NOT to have picked up sub/'s (unparseable) language", out)
+	}
+}

--- a/generate.go
+++ b/generate.go
@@ -645,12 +645,22 @@ func (gen *Generator) loadZasDirectoryConfig(currentpath string) (config ConfigS
 		return entry.config, entry.modTime, err
 	}
 	config = make(ConfigSection)
-	_ = yaml.Unmarshal(data, &config)
+	if yamlErr := yaml.Unmarshal(data, &config); yamlErr != nil {
+		// A malformed .zas.yml would otherwise look like a completely
+		// successful, merely empty, config load (err == nil here), and that
+		// empty config is about to be memoized for the rest of this run: no
+		// page under this directory would ever see a diagnostic for it.
+		// Route it through the same aggregation/reporting path every other
+		// config-loading failure (parseLayout, loadI18N, ...) already uses,
+		// so it surfaces once, without aborting the rest of the build.
+		err = fmt.Errorf("%s: %w", confPath, yamlErr)
+		gen.recordErr(err)
+	}
 	if info, statErr := os.Stat(confPath); statErr == nil {
 		modTime = info.ModTime()
 	}
 	gen.setCachedDirConfig(path, dirConfigEntry{config: config, modTime: modTime})
-	return config, modTime, nil
+	return config, modTime, err
 }
 
 /*
@@ -696,20 +706,19 @@ func (gen *Generator) render(path string, input []byte) (err error) {
 	}
 	doc, err := gen.parseAndReplace(processed, &data)
 	if err != nil {
-		gen.printLine(err)
 		return
 	}
 	gen.cleanUnnecessaryPTags(doc)
-	data.Page, err = gen.extractPageConfig(doc)
-	if err != nil {
-		gen.printLine(path, "=>", err)
-		err = nil
+	var pageErr error
+	data.Page, pageErr = gen.extractPageConfig(doc)
+	if pageErr != nil {
+		// A malformed page-config comment is reported but doesn't abort the
+		// render: it's kept out of the named err return (unlike every other
+		// error in this function) so the rest of the page still renders.
+		gen.printLine(path, "=>", pageErr)
 	}
 	data.FirstTitle = gen.getTitle(doc)
 	body := doc.Find(atom.Body.String())
-	if err != nil {
-		return
-	}
 	if body.Size() > 0 {
 		bodyHTML, bodyErr := body.Html()
 		if bodyErr != nil {
@@ -778,7 +787,7 @@ func (gen *Generator) extractPageConfig(doc *goquery.Document) (config map[inter
 		}
 	}
 	if comment != nil {
-		_ = yaml.Unmarshal([]byte(comment.Data), &config)
+		err = yaml.Unmarshal([]byte(comment.Data), &config)
 	}
 	return
 }

--- a/render_error_reporting_test.go
+++ b/render_error_reporting_test.go
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2013 Dario Castañé.
+ * This file is part of Zas.
+ *
+ * Zas is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Zas is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Zas.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package zas
+
+import (
+	thtml "html/template"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/melvinmt/gt"
+)
+
+// captureStdout is defined in symlink_test.go and reused here.
+
+// newRenderTestGenerator builds a minimal Generator suitable for calling
+// render() directly, deploying into ./deploy under a fresh chdir'd temp
+// directory.
+func newRenderTestGenerator(t *testing.T) *Generator {
+	t.Helper()
+	t.Chdir(t.TempDir())
+	if err := os.MkdirAll("deploy", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gen := &Generator{
+		Config: ConfigSection{"zas": ConfigSection{"deploy": "deploy"}},
+		I18n:   &gt.Build{Index: gt.Strings{}, Origin: "en"},
+	}
+	layout, err := thtml.New("layout").Funcs(helpers).Parse(`<body>{{.Body}}</body>`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gen.Layout = layout
+	return gen
+}
+
+// render's own call to parseAndReplace used to both print the error
+// directly (gen.printLine(err)) and return it as render's error, which its
+// caller renderAsync already aggregates into gen.errs and reports through
+// the normal single-report-per-error path - so this one error type was
+// reported twice. It must now be reported exactly once, by the caller.
+func TestRenderParseAndReplaceErrorNotPrintedInline(t *testing.T) {
+	gen := newRenderTestGenerator(t)
+	// An embed type nothing resolves a plugin for makes handleEmbedTags -
+	// and therefore render's own top-level parseAndReplace call - fail.
+	src := `<body><embed src="x" type="text/x-nope"></body>`
+
+	var err error
+	stdout := captureStdout(t, func() {
+		err = gen.render("page.html", []byte(src))
+	})
+
+	if err == nil {
+		t.Fatal("render() error = nil, want the embed-plugin error propagated")
+	}
+	if !strings.Contains(err.Error(), "text/x-nope") {
+		t.Fatalf("render() error = %v, want it to mention the embed type", err)
+	}
+	if strings.Contains(stdout, "text/x-nope") {
+		t.Fatalf("render() printed the error directly to stdout (%q); it must be reported exactly once, by its caller", stdout)
+	}
+}
+
+// extractPageConfig used to unconditionally discard its own
+// yaml.Unmarshal error (_ = yaml.Unmarshal(...)), so its named err return
+// could never be non-nil. It must now propagate a real error for malformed
+// YAML in the page's config comment.
+func TestExtractPageConfigPropagatesYAMLError(t *testing.T) {
+	gen := &Generator{}
+	src := "<!-- language: ru\n\tbad: true\n-->\n<h1>Hi</h1>"
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := gen.extractPageConfig(doc); err == nil {
+		t.Fatal("extractPageConfig() with a malformed YAML config comment: want error, got nil")
+	}
+}
+
+// With extractPageConfig actually propagating its error, render's
+// print-then-continue branch for it becomes live: the malformed comment
+// must be reported, but must not abort rendering the rest of the page.
+func TestRenderReportsMalformedPageConfigCommentButKeepsGoing(t *testing.T) {
+	gen := newRenderTestGenerator(t)
+	src := "<!-- language: ru\n\tbad: true\n-->\n<h1>Hi</h1>"
+
+	var err error
+	stdout := captureStdout(t, func() {
+		err = gen.render("page.html", []byte(src))
+	})
+
+	if err != nil {
+		t.Fatalf("render() error = %v, want nil (a malformed page config comment must not abort the render)", err)
+	}
+	if !strings.Contains(stdout, "page.html") {
+		t.Fatalf("render() stdout = %q, want it to report the malformed page config comment", stdout)
+	}
+
+	out, readErr := os.ReadFile(filepath.Join("deploy", "page.html"))
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !strings.Contains(string(out), "<h1>Hi</h1>") {
+		t.Fatalf("deploy output = %q, want the page body still rendered despite the malformed config comment", out)
+	}
+}


### PR DESCRIPTION
## Summary
- `loadZasDirectoryConfig` discarded a malformed `.zas.yml`'s `yaml.Unmarshal` error entirely, so a bad file silently produced an empty config (`err == nil`) that then got memoized for the rest of the run with no diagnostic anywhere. It now records the parse error through the same aggregation/reporting path other config-loading failures (`parseLayout`, `loadI18N`, ...) already use.
- `extractPageConfig` had the identical bug for a page's own YAML config comment, which made a chunk of `render`'s error handling unreachable dead code (a "print and continue" branch that could never fire, plus a second `if err != nil { return }` check that was equally dead). `extractPageConfig` now propagates its `yaml.Unmarshal` error, making that handling live, and the redundant dead check is removed.
- `render` printed the error from its own `parseAndReplace` call directly, on top of returning it as `render`'s own result - which its caller already aggregates and reports through the normal per-file error path, so that error type was reported twice. The inline print is removed.
- `data.go`'s `Resolve` discards `Extra`'s error the same way, but its existing doc comment already documents that as a deliberate, previously-reasoned-through fallback for a genuinely absent config key - left unchanged.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .`, `golangci-lint run ./...` all clean
- [x] `go test -race -count=1 ./...` passes, including new tests:
  - `TestLoadZasDirectoryConfigMalformedYAMLSurfacesError` / `TestGenerateReportsMalformedDirectoryConfig`: malformed `.zas.yml` now surfaces its parse error instead of silently caching an empty config
  - `TestRenderParseAndReplaceErrorNotPrintedInline`: the `parseAndReplace` error case in `render` is reported exactly once, not twice
  - `TestExtractPageConfigPropagatesYAMLError` / `TestRenderReportsMalformedPageConfigCommentButKeepsGoing`: a malformed page-config comment is now visibly reported while the page still renders
- [x] Verified the new tests fail against the pre-fix code and pass against the fix
- [x] Manually reproduced with the built `zas` binary: a malformed directory `.zas.yml` now fails the build with a clear message while still rendering the affected page; a malformed page-config comment is reported once and the page still renders; a normal valid site still builds cleanly with no spurious output