### PR TITLE
feat(generate): let a page opt out of standalone publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ Keep in mind that any file will be treated as a Go text template before any furt
 * `{{.Resolve id}}`: indirect access to site, directory and page config. It works with simple keys (no paths), checking for them in page, directory and site config (as `/site/<id>`), in this order.
 * `{{.Language}}`: file current language, if defined in the first comment (as YAML property `language`). By default, `/site/language` value.
 
+There is also a page config property that isn't exposed as a template field, since it steers generation itself rather than the page's content:
+
+* `publish`: set to `false` in a file's config comment to keep that file out of `.zas/deploy` as a standalone page, while it stays fully available to be pulled into another page via `<embed>`. Defaults to `true` (published), so existing files are unaffected.
+
 ### What about layout.html?
 
 It is plain HTML. No frills. Just add a placeholder `{{.Body}}` in your template.
@@ -196,6 +200,16 @@ No problem! Just use our old friend `<embed>`. Imagine `<layout>` is a valid tag
 ```
 
 What does it mean? It means you can have .html files with embedded markdown files. Or anything else supported by Zas.
+
+`navigation.md` here probably isn't meant to be its own page, only content embedded into others - so mark it with `publish: false` in its own config comment:
+
+```markdown
+<!-- publish: false -->
+* [Home](/)
+* [About](/about.html)
+```
+
+Zas still reads and processes `navigation.md` normally wherever it's embedded, but it won't also show up on its own at `/navigation.html` in the deploy output.
 
 ## 你会说普通话?
 

--- a/generate.go
+++ b/generate.go
@@ -496,6 +496,13 @@ func (gen *Generator) renderAsync(path string) {
 
 /*
  * Real reaping function. Reaps all missing source files in current deployment path.
+ *
+ * This only reaps deploy output whose source file no longer exists; it does
+ * not detect a source file that still exists but newly opted out of
+ * standalone publishing via "publish: false" (see pagePublished). That
+ * page's previous deploy output is left behind by an incremental run - a
+ * -full run, which clears the whole deploy directory upfront, is needed to
+ * remove it.
  */
 func (gen *Generator) reaper(path string, _ os.FileInfo, err error) (ierr error) {
 	if err != nil {
@@ -724,7 +731,44 @@ func (gen *Generator) render(path string, input []byte) (err error) {
 			}
 		}
 	}
+	if !pagePublished(data.Page) {
+		// This is the answer to upstream issue #15 ("How can we exclude a
+		// file from the generation loop?"): a page opts out of being
+		// written to the deploy directory as its own standalone file with
+		// "publish: false" in its config comment - e.g. a partial that only
+		// ever makes sense embedded into another page via <embed>. The file
+		// is still fully parsed above (so its own template/embeds/page
+		// config all work exactly as before) and stays fully readable and
+		// processable when pulled in elsewhere: Markdown/Plain/Html read
+		// and process the target file directly via os.ReadFile and
+		// resolveEmbedSrc, independent of this decision.
+		//
+		// The flag only lives inside the page's own content, so walk can't
+		// know about it before render parses this far - meaning an
+		// excluded page never has a deploy output for sourceIsNewer to
+		// compare mtimes against, and so is treated as stale (fully
+		// re-parsed, though never written) on every incremental run. This
+		// is a minor inefficiency, not a correctness bug.
+		//
+		// It also means reaper - which only removes deploy output whose
+		// source no longer exists - won't notice a page that keeps
+		// existing but newly opts out with "publish: false": a
+		// previously-published file's stale output under .zas/deploy
+		// survives an incremental run and needs a -full run (which clears
+		// the whole deploy directory upfront) to actually disappear.
+		return nil
+	}
 	return gen.Generate(path, &data)
+}
+
+// pagePublished reports whether a page should be written to the deploy
+// directory as its own standalone file. A page opts out with "publish:
+// false" in its config comment; any other value, or the key's absence,
+// keeps the pre-existing default of publishing every page render
+// produces.
+func pagePublished(page map[interface{}]interface{}) bool {
+	publish, ok := page["publish"].(bool)
+	return !ok || publish
 }
 
 /*

--- a/page_publish_test.go
+++ b/page_publish_test.go
@@ -1,0 +1,121 @@
+package zas
+
+import (
+	thtml "html/template"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/melvinmt/gt"
+)
+
+// Coverage for the "publish: false" page-config key (upstream issue #15:
+// "How can we exclude a file from the generation loop?"). It lets a file
+// that only ever makes sense embedded elsewhere - a nav partial, for
+// instance - opt out of also being written to the deploy directory as its
+// own standalone page, without an underscore-prefix naming convention.
+
+func TestPagePublishedDefaultsTrue(t *testing.T) {
+	if !pagePublished(nil) {
+		t.Fatal("pagePublished(nil) = false, want true")
+	}
+	if !pagePublished(map[interface{}]interface{}{}) {
+		t.Fatal("pagePublished(empty) = false, want true")
+	}
+	if !pagePublished(map[interface{}]interface{}{"title": "Nav"}) {
+		t.Fatal("pagePublished(no publish key) = false, want true")
+	}
+}
+
+func TestPagePublishedExplicitTrue(t *testing.T) {
+	if !pagePublished(map[interface{}]interface{}{"publish": true}) {
+		t.Fatal("pagePublished(publish: true) = false, want true")
+	}
+}
+
+func TestPagePublishedFalse(t *testing.T) {
+	if pagePublished(map[interface{}]interface{}{"publish": false}) {
+		t.Fatal("pagePublished(publish: false) = true, want false")
+	}
+}
+
+func TestPagePublishedNonBoolValueDefaultsTrue(t *testing.T) {
+	// A typo'd or unexpected value (e.g. a string) must not be silently
+	// treated as an exclusion - only an actual boolean false does that.
+	if !pagePublished(map[interface{}]interface{}{"publish": "false"}) {
+		t.Fatal(`pagePublished(publish: "false") = false, want true (only a real bool false excludes)`)
+	}
+}
+
+// TestRenderSkipsDeployOutputWhenPublishFalse drives render() directly
+// (like TestRenderPageBodyCanCallPointerReceiverMethod in
+// page_data_test.go) to confirm a page whose config comment sets
+// "publish: false" never gets a deploy file written for it, while
+// render() itself still returns no error.
+func TestRenderSkipsDeployOutputWhenPublishFalse(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.MkdirAll("deploy", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gen := &Generator{
+		Config: ConfigSection{
+			"zas":  ConfigSection{"deploy": "deploy"},
+			"site": ConfigSection{"baseurl": "http://example.com"},
+		},
+		I18n: &gt.Build{Index: gt.Strings{}, Origin: "en"},
+	}
+	layout, err := thtml.New("layout").Funcs(helpers).Parse(`{{.Body}}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gen.Layout = layout
+
+	source := "<!-- publish: false -->\n<nav><a href=\"/index.html\">Home</a></nav>\n"
+	if err := gen.render("partials/nav.html", []byte(source)); err != nil {
+		t.Fatalf("render() error = %v, want nil", err)
+	}
+
+	if _, err := os.Stat(filepath.Join("deploy", "partials", "nav.html")); !os.IsNotExist(err) {
+		t.Fatalf("deploy/partials/nav.html stat err = %v, want a not-exist error", err)
+	}
+}
+
+// TestGenerateExcludedPartialNotPublishedButStillEmbeds runs a full
+// Generator.Run() over testdata/site, whose partials/nav.html carries
+// "publish: false" and is embedded into index.html via <embed>. It
+// confirms the exclusion actually reaches end to end: the partial itself
+// never lands in the deploy tree, its content still shows up inside
+// index.html's deployed output, and an ordinary page with no publish
+// key (about.html) is generated exactly as before.
+func TestGenerateExcludedPartialNotPublishedButStillEmbeds(t *testing.T) {
+	newTestSite(t, "site")
+	if err := generate(t); err != nil {
+		t.Fatalf("generate() error = %v, want nil", err)
+	}
+
+	// walk still creates the deploy-side "partials" directory itself (it
+	// mirrors every source directory regardless of what ends up inside
+	// it), so only the excluded file's own output is asserted missing.
+	assertDeployMissing(t, filepath.Join("partials", "nav.html"))
+
+	out := readDeploy(t, "index.html")
+	if !strings.Contains(out, "<nav>") || !strings.Contains(out, "Home</a>") {
+		t.Fatalf("index.html = %q, want it to still contain the embedded nav content", out)
+	}
+
+	assertDeployHas(t, "about.html")
+	assertDeployHas(t, filepath.Join("sub", "page.html"))
+}
+
+// TestGenerateExcludedPartialFullRunAlsoOmitsIt confirms the exclusion
+// holds under -full generation too, not just the incremental path.
+func TestGenerateExcludedPartialFullRunAlsoOmitsIt(t *testing.T) {
+	newTestSite(t, "site")
+	if err := generate(t, fullGen); err != nil {
+		t.Fatalf("generate() error = %v, want nil", err)
+	}
+
+	assertDeployMissing(t, filepath.Join("partials", "nav.html"))
+	assertDeployHas(t, "index.html")
+}

--- a/testdata/site/partials/nav.html
+++ b/testdata/site/partials/nav.html
@@ -1,1 +1,2 @@
+<!-- publish: false -->
 <nav><a href="/index.html">Home</a></nav>


### PR DESCRIPTION
## Summary

Every `.md`/`.html` file `walk` finds is rendered and deployed as its
own standalone page - even a file meant only to be embedded into
another page via `<embed>`, with no way to opt out. This is the same
problem as upstream issue #15 ("How can we exclude a file from the
generation loop?"). The repo's own `testdata/site` fixture demonstrated
it: `partials/nav.html` is embedded into `index.html`, but also got
independently rendered and published on its own at
`.zas/deploy/partials/nav.html`.

An underscore-prefix convention (Jekyll/Hugo-style `_partial.html`)
would contradict this project's own stated "unobtrusive structure, no
`_` files" design, so this uses the existing per-page config-comment
channel instead: a page can now set `publish: false` in its own
`<!-- key: value -->` config comment (the same mechanism
`extractPageConfig` already reads for `title`, `language`, etc.) to
keep its own render out of the deploy directory, while staying fully
readable and processable wherever it's embedded - the `Markdown`/
`Plain`/`Html` embed handlers already read and process their target
file directly, independent of whatever `walk`/`render` decided about
standalone publishing.

The flag only becomes known once `render` has parsed the page that
far (via `parseAndReplace` + `extractPageConfig`), so it's checked
right before the final `gen.Generate` call inside `render()` rather
than earlier in `walk`.

Two pre-existing incremental-mode/reaper gaps apply to an excluded
page too, and are now documented in code where they arise:

- An excluded page never has a deploy output for `sourceIsNewer` to
  compare mtimes against, so it's fully re-parsed (though never
  written) on every incremental run. Minor inefficiency, not a
  correctness bug.
- If a page was previously published and later opts out, `reaper`
  only removes deploy output whose *source* no longer exists, not
  output whose source merely opted out - so the stale file survives
  an incremental run and needs a `-full` run (which clears the whole
  deploy directory upfront) to actually disappear.

`testdata/site/partials/nav.html` now carries `publish: false` as a
live example of the exact case the finding reproduces, and the
README's embed walkthrough and page-config field list are updated to
match.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` all clean
- [x] `golangci-lint run ./...`: 0 issues
- [x] `go test -race -count=1 ./...`: all passing
- [x] New tests in `page_publish_test.go`: unit coverage for the
      `publish: false` default/override/non-bool cases, a `render()`-level
      test confirming no deploy file is written, and end-to-end
      `Generator.Run()` tests (incremental and `-full`) confirming
      `testdata/site`'s `partials/nav.html` is absent from the deploy tree
      while still showing up embedded in `index.html`, and that ordinary
      pages are unaffected
- [x] Live repro: built the `zas` binary, created a fixture site with
      `partials/nav.html` marked `publish: false` and embedded into
      `index.html`, ran `zas generate` - confirmed `partials/nav.html`
      never appears under `.zas/deploy` while `index.html`'s deployed
      output contains the embedded nav content, and a normal page
      (`about.md`) deploys as usual