### PR TITLE
feat(generate): let a page opt out of text/template execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,19 @@ Keep in mind that any file will be treated as a Go text template before any furt
 * `{{.Resolve id}}`: indirect access to site, directory and page config. It works with simple keys (no paths), checking for them in page, directory and site config (as `/site/<id>`), in this order.
 * `{{.Language}}`: file current language, if defined in the first comment (as YAML property `language`). By default, `/site/language` value.
 
+If a file's own content needs to contain literal `{{...}}` - a Vue/Angular/Handlebars snippet, Go template documentation, or a code sample showing off Zas's own template syntax - set `template: false` in its config comment instead of escaping every brace:
+
+```markdown
+<!--
+title: Templating in Zas
+template: false
+-->
+Zas actions look like `{{.Title}}`, and this whole page is written to
+show them off, so it opts out of being templated itself.
+```
+
+The file is still fully parsed and processed otherwise (HTML5 parsing, `<embed>`, and its own config comment - `title` above still works), only its content is never run through `text/template`. Defaults to `true` (templated), so existing files are unaffected.
+
 ### What about layout.html?
 
 It is plain HTML. No frills. Just add a placeholder `{{.Body}}` in your template.

--- a/generate.go
+++ b/generate.go
@@ -784,6 +784,73 @@ func hasFoldPrefix(b []byte, prefix string) bool {
 	return true
 }
 
+// templateKey is the one map key pageOptsOutOfTemplating cares about.
+// bomUTF16LE/bomUTF16BE are the two byte-order marks yaml.v2 recognizes at
+// the very start of a stream - see mayDefineTemplateKey, the only place
+// either is used.
+var templateKey = []byte("template")
+
+const (
+	bomUTF16LE = "\xff\xfe"
+	bomUTF16BE = "\xfe\xff"
+)
+
+// mayDefineTemplateKey reports whether content could possibly decode to a
+// YAML mapping containing the exact key "template", without actually
+// running the parser to find out. It exists to keep yaml.Unmarshal off the
+// hot path: gopkg.in/yaml.v2's yaml_parser_initialize allocates the
+// parser's two I/O buffers (512 and 1536 bytes) on every single Unmarshal
+// call regardless of input size, so asking an eleven-byte
+// "<!-- title: Hi -->" comment for a key it doesn't have costs ~4.5us and
+// ~5.5KB - once per page, on every render, across renderConcurrency()
+// goroutines.
+//
+// A false positive here only costs the yaml parse that would have run
+// anyway, so the bar is one-sided: this must never say false for content
+// yaml would in fact decode with a "template" key. Every YAML 1.1
+// construct that can put a key into the map either reproduces that key's
+// bytes verbatim or needs one of the three markers checked below - verified
+// against gopkg.in/yaml.v2 v2.4.0's actual source, not just the spec:
+//
+//   - Plain and single-quoted scalars reproduce their bytes. A line break
+//     inside one folds to a space, so "temp\nlate" decodes as "temp late"
+//     and can never be rejoined into "template"; block scalars (| and >),
+//     explicit "? " keys and flow mappings are just other ways to spell
+//     those same bytes. Anchors, aliases and "<<" merge keys can only
+//     reach a key some node in this very document already spells out, and
+//     yaml.Unmarshal is handed nothing but the comment's own bytes.
+//   - A double-quoted scalar can synthesize the key ("\x74emplate", or a
+//     backslash-newline continuation joining "temp" and "late"), but every
+//     such form needs a backslash.
+//   - So can a tag: yaml.v2 base64-decodes !!binary into a Go string
+//     (decode.go's scalar case deliberately excludes yaml_BINARY_TAG from
+//     resolvableTag in resolve.go, so it skips normal resolution and hits
+//     the base64 branch instead), which makes
+//     "<!-- !!binary dGVtcGxhdGU=: false -->" - base64 of "template" - a
+//     real opt-out today that never spells the key in the comment. Every
+//     way to name that tag - the !! shorthand, a verbatim !<...>, or a
+//     %TAG-remapped handle - puts a '!' somewhere in the document, because
+//     a tag handle is delimited by them.
+//   - The bytes need not be UTF-8 at all. yaml.v2 sniffs a UTF-16 byte
+//     order mark and transcodes (readerc.go's
+//     yaml_parser_determine_encoding), so a comment body opening with
+//     FF FE spells the key as 74 00 65 00 ... instead of literal ASCII.
+//     That sniff happens once, at the very start of the stream and
+//     nowhere else, so a two-byte prefix check is exact rather than
+//     another scan.
+//
+// The key is matched case-sensitively on purpose: the lookup this feeds is
+// config["template"], an exact Go string comparison, so "Template: false"
+// is not an opt-out today and must not become one here.
+func mayDefineTemplateKey(content []byte) bool {
+	if hasPrefix(content, bomUTF16LE) || hasPrefix(content, bomUTF16BE) {
+		return true
+	}
+	return bytes.Contains(content, templateKey) ||
+		bytes.IndexByte(content, '\\') >= 0 ||
+		bytes.IndexByte(content, '!') >= 0
+}
+
 // pageOptsOutOfTemplating reports whether input's leading config comment
 // sets "template: false", letting a whole page skip text/template
 // parsing/execution so its content - including any literal {{ }} it
@@ -807,6 +874,12 @@ func pageOptsOutOfTemplating(input []byte) bool {
 	if !ok {
 		return false
 	}
+	if !mayDefineTemplateKey(content) {
+		// yaml could only confirm what the scan above already
+		// established, and it is by far the most expensive thing this
+		// function does - see mayDefineTemplateKey.
+		return false
+	}
 	var config map[interface{}]interface{}
 	if err := yaml.Unmarshal(content, &config); err != nil {
 		return false
@@ -814,6 +887,18 @@ func pageOptsOutOfTemplating(input []byte) bool {
 	runTemplate, ok := config["template"].(bool)
 	return ok && !runTemplate
 }
+
+// templateActionOpen is text/template's default left delimiter, and the
+// only one render's template ever uses - nothing in this repo calls
+// ttext.New(...).Delims(...). A page containing no "{{" anywhere therefore
+// has no template actions at all: not a "{{- -}}" trim marker, not a
+// "{{/* */}}" comment, since text/template's lexer (lexText in
+// text/template/parse/lex.go) only reaches either past this same
+// delimiter. With none present, Parse builds a tree holding a single text
+// node and Execute copies it back out byte for byte - so render's
+// no-templating branch below produces the identical result without paying
+// for string(input)'s full-file copy or the parse/execute round trip.
+var templateActionOpen = []byte("{{")
 
 /*
  * Generic render function. It expects input to be a valid HTML document.
@@ -825,7 +910,18 @@ func (gen *Generator) render(path string, input []byte) (err error) {
 	// Building context and rendering template.
 	data := NewZasData(path, gen)
 	data.Directory, _, _ = gen.loadZasDirectoryConfig(path)
-	if pageOptsOutOfTemplating(input) {
+	// The "{{" check goes first, and that order is load-bearing rather
+	// than stylistic: when input has no "{{" at all, templating and the
+	// opt-out branch below produce byte-identical output regardless of
+	// what the page's config comment says, so pageOptsOutOfTemplating's
+	// answer cannot change the outcome, and || short-circuits it away
+	// entirely. That matters because mayDefineTemplateKey's guards are
+	// deliberately one-sided (an innocuous "!" or backslash anywhere in
+	// the comment - "Hi!", a Windows path in a title - still falls
+	// through to a real yaml.Unmarshal); putting bytes.Contains first
+	// means a plain page never pays for that parse over a question whose
+	// answer was never going to matter.
+	if !bytes.Contains(input, templateActionOpen) || pageOptsOutOfTemplating(input) {
 		// input flows through unchanged: no text/template parsing or
 		// execution at all, so a literal {{ }} anywhere in it - including
 		// inside a fenced code block - survives verbatim into the rest of

--- a/generate.go
+++ b/generate.go
@@ -685,24 +685,75 @@ func (gen *Generator) setCachedDirConfig(path string, entry dirConfigEntry) {
 	gen.cachedZasDirectoryConfigs[path] = entry
 }
 
+// pageConfigCommentRe extracts a page's leading config comment straight
+// from its raw source bytes, tolerating a single leading <!DOCTYPE ...>
+// ahead of it (the same tolerance extractPageConfig has once the document
+// is fully HTML5-parsed) and any whitespace before either. It exists only
+// so pageOptsOutOfTemplating can decide, before text/template ever runs,
+// whether it should run at all - see that function and the comment on
+// render's ttext.New call below for why extractPageConfig itself can't be
+// used for this.
+var pageConfigCommentRe = regexp.MustCompile(`(?is)\A\s*(?:<!DOCTYPE[^>]*>\s*)?<!--(.*?)-->`)
+
+// pageOptsOutOfTemplating reports whether input's leading config comment
+// sets "template: false", letting a whole page skip text/template
+// parsing/execution so its content - including any literal {{ }} it
+// contains - reaches the rest of the pipeline unexecuted. This is for
+// pages that use {{ }} for something other than Zas's own templating: a
+// Vue/Angular/Handlebars snippet, Go-template documentation, or a code
+// sample demonstrating Zas's own template syntax.
+//
+// It has to inspect input's raw bytes directly, before ttext.New(...).Parse
+// runs. extractPageConfig reads this same leading comment for every other
+// page-config key (title, language, ...), but only runs later in render, on
+// the document produced by executing that very template - so by the time
+// it could report "template: false", template execution has already
+// happened (or already failed). A comment that isn't valid YAML is treated
+// the same as one without a "template" key (templating proceeds as
+// before): extractPageConfig will report the same malformed comment once
+// the page reaches it further down the pipeline, so it doesn't need to be
+// reported twice.
+func pageOptsOutOfTemplating(input []byte) bool {
+	m := pageConfigCommentRe.FindSubmatch(input)
+	if m == nil {
+		return false
+	}
+	var config map[interface{}]interface{}
+	if err := yaml.Unmarshal(m[1], &config); err != nil {
+		return false
+	}
+	runTemplate, ok := config["template"].(bool)
+	return ok && !runTemplate
+}
+
 /*
  * Generic render function. It expects input to be a valid HTML document.
- * Input can be a valid Go template.
+ * Input can be a valid Go template, unless its leading config comment
+ * opts out with "template: false" (see pageOptsOutOfTemplating).
  */
 func (gen *Generator) render(path string, input []byte) (err error) {
-	template, err := ttext.New("current").Parse(string(input))
-	if err != nil {
-		return
-	}
 	var processed bytes.Buffer
 	// Building context and rendering template.
 	data := NewZasData(path, gen)
 	data.Directory, _, _ = gen.loadZasDirectoryConfig(path)
-	// Pass a pointer: text/template only sees pointer-receiver methods
-	// (Title, E, URL, ...) on an addressable value, and a plain "data" here
-	// is not addressable.
-	if err = template.Execute(&processed, &data); err != nil {
-		return
+	if pageOptsOutOfTemplating(input) {
+		// input flows through unchanged: no text/template parsing or
+		// execution at all, so a literal {{ }} anywhere in it - including
+		// inside a fenced code block - survives verbatim into the rest of
+		// the pipeline below (HTML5 parsing, embeds, page config, ...),
+		// exactly like every other byte of a normal page would.
+		_, _ = processed.Write(input)
+	} else {
+		var template *ttext.Template
+		if template, err = ttext.New("current").Parse(string(input)); err != nil {
+			return
+		}
+		// Pass a pointer: text/template only sees pointer-receiver methods
+		// (Title, E, URL, ...) on an addressable value, and a plain "data" here
+		// is not addressable.
+		if err = template.Execute(&processed, &data); err != nil {
+			return
+		}
 	}
 	doc, err := gen.parseAndReplace(processed, &data)
 	if err != nil {

--- a/generate.go
+++ b/generate.go
@@ -685,7 +685,18 @@ func (gen *Generator) setCachedDirConfig(path string, entry dirConfigEntry) {
 	gen.cachedZasDirectoryConfigs[path] = entry
 }
 
-// pageConfigCommentRe extracts a page's leading config comment straight
+// doctypePrefix and commentOpen/commentClose are the literal delimiters
+// leadingConfigComment scans for. Matching regexp's (?is) \s class exactly,
+// not unicode.IsSpace, is what makes isConfigSpace its own function below
+// rather than a reuse of a stdlib whitespace check.
+const (
+	doctypePrefix = "<!DOCTYPE"
+	commentOpen   = "<!--"
+)
+
+var commentClose = []byte("-->")
+
+// leadingConfigComment extracts a page's leading config comment straight
 // from its raw source bytes, tolerating a single leading <!DOCTYPE ...>
 // ahead of it (the same tolerance extractPageConfig has once the document
 // is fully HTML5-parsed) and any whitespace before either. It exists only
@@ -693,7 +704,85 @@ func (gen *Generator) setCachedDirConfig(path string, entry dirConfigEntry) {
 // whether it should run at all - see that function and the comment on
 // render's ttext.New call below for why extractPageConfig itself can't be
 // used for this.
-var pageConfigCommentRe = regexp.MustCompile(`(?is)\A\s*(?:<!DOCTYPE[^>]*>\s*)?<!--(.*?)-->`)
+//
+// It walks input by hand as a small state machine - skip whitespace, try
+// an optional doctype, skip whitespace again, require the comment to open
+// immediately, then scan for its close - instead of using regexp, since
+// this runs once per source file on every render() call and is on the hot
+// path for a large site. It reproduces
+// `(?is)\A\s*(?:<!DOCTYPE[^>]*>\s*)?<!--(.*?)-->` byte for byte: in
+// particular the scan for "-->" stops at the *first* occurrence (a later
+// comment further into input must never count), and any mismatch anchored
+// at the very start of input - after whitespace/doctype - means there is
+// no leading comment at all.
+func leadingConfigComment(input []byte) ([]byte, bool) {
+	i := skipConfigSpace(input, 0)
+	if hasFoldPrefix(input[i:], doctypePrefix) {
+		end := bytes.IndexByte(input[i:], '>')
+		if end < 0 {
+			// No closing '>' for the doctype: the optional group can't
+			// have matched, but input at i still starts with "<!DOCTYPE",
+			// which can never also start with "<!--", so there is no
+			// leading comment either way.
+			return nil, false
+		}
+		i += end + 1
+		i = skipConfigSpace(input, i)
+	}
+	if !hasPrefix(input[i:], commentOpen) {
+		return nil, false
+	}
+	i += len(commentOpen)
+	end := bytes.Index(input[i:], commentClose)
+	if end < 0 {
+		return nil, false
+	}
+	return input[i : i+end], true
+}
+
+// skipConfigSpace advances i past any run of configSpace bytes.
+func skipConfigSpace(input []byte, i int) int {
+	for i < len(input) && isConfigSpace(input[i]) {
+		i++
+	}
+	return i
+}
+
+// isConfigSpace reports whether b is one of regexp's \s bytes
+// ([\t\n\f\r ]), matching the whitespace class the original
+// pageConfigCommentRe relied on exactly.
+func isConfigSpace(b byte) bool {
+	switch b {
+	case '\t', '\n', '\f', '\r', ' ':
+		return true
+	}
+	return false
+}
+
+// hasPrefix reports whether b starts with prefix. Comparing a sliced
+// []byte-to-string conversion with == is a case the compiler recognizes
+// and doesn't allocate for.
+func hasPrefix(b []byte, prefix string) bool {
+	return len(b) >= len(prefix) && string(b[:len(prefix)]) == prefix
+}
+
+// hasFoldPrefix is hasPrefix's ASCII case-insensitive counterpart, used
+// only for the (case-insensitive) "<!DOCTYPE" tag.
+func hasFoldPrefix(b []byte, prefix string) bool {
+	if len(b) < len(prefix) {
+		return false
+	}
+	for i := 0; i < len(prefix); i++ {
+		c := b[i]
+		if 'a' <= c && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		if c != prefix[i] {
+			return false
+		}
+	}
+	return true
+}
 
 // pageOptsOutOfTemplating reports whether input's leading config comment
 // sets "template: false", letting a whole page skip text/template
@@ -714,12 +803,12 @@ var pageConfigCommentRe = regexp.MustCompile(`(?is)\A\s*(?:<!DOCTYPE[^>]*>\s*)?<
 // the page reaches it further down the pipeline, so it doesn't need to be
 // reported twice.
 func pageOptsOutOfTemplating(input []byte) bool {
-	m := pageConfigCommentRe.FindSubmatch(input)
-	if m == nil {
+	content, ok := leadingConfigComment(input)
+	if !ok {
 		return false
 	}
 	var config map[interface{}]interface{}
-	if err := yaml.Unmarshal(m[1], &config); err != nil {
+	if err := yaml.Unmarshal(content, &config); err != nil {
 		return false
 	}
 	runTemplate, ok := config["template"].(bool)

--- a/raw_page_bench_test.go
+++ b/raw_page_bench_test.go
@@ -19,26 +19,123 @@
 package zas
 
 import (
+	thtml "html/template"
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/melvinmt/gt"
 )
 
-// pageOptsOutOfTemplatingInputs are representative render() inputs:
+// largeBody is the body every "large" case below shares: big enough that a
+// full-input scan is measurable, and identical across cases so the only
+// variable being benchmarked is the leading comment.
+var largeBody = "<h1>Hi</h1>\n" + strings.Repeat("<p>filler paragraph content</p>\n", 2000)
+
+// pageOptsOutOfTemplatingInputs are representative render() inputs, a slice
+// (not a map) so benchstat output has a stable order to diff against.
 // pageOptsOutOfTemplating runs once per source file on every render() call,
-// so it needs to stay cheap regardless of how big the rest of the page is.
-var pageOptsOutOfTemplatingInputs = map[string]string{
-	"small_with_comment":  "<!-- title: Hi -->\n<h1>Hi</h1>",
-	"large_body_no_match": "<!-- title: Hi -->\n<h1>Hi</h1>" + strings.Repeat("<p>filler paragraph content</p>\n", 2000),
-	"no_comment_at_all":   strings.Repeat("<p>filler paragraph content</p>\n", 2000),
+// so it needs to stay cheap regardless of what its comment looks like or
+// how big the rest of the page is.
+var pageOptsOutOfTemplatingInputs = []struct {
+	name  string
+	input string
+}{
+	// No leading comment: leadingConfigComment rejects on the very first
+	// byte, so neither the key scan nor yaml ever runs.
+	{"no_comment", "<h1>Hi</h1>"},
+	// The ordinary case every ordinary page hits: a comment that sets
+	// title/language but never mentions "template" - this is the shape
+	// mayDefineTemplateKey exists to keep off the yaml.Unmarshal path.
+	{"comment_without_template_key", "<!-- title: Hi -->\n<h1>Hi</h1>"},
+	// A comment that really does carry the key, so the scan can't rule it
+	// out and yaml still has to run - the case this change doesn't speed
+	// up, benchmarked so a regression there would show.
+	{"comment_with_template_key", "<!-- template: false -->\n<h1>Hi</h1>"},
+	// A backslash defeats the scan's guard even with no "template" key
+	// present, so this pays a full yaml parse it didn't strictly need -
+	// the deliberate, documented cost of keeping the scan provably exact.
+	{"comment_with_backslash", `<!-- title: C:\docs -->` + "\n<h1>Hi</h1>"},
+	// Same shape as comment_without_template_key, but with a large body
+	// after the comment: leadingConfigComment stops at the first "-->",
+	// so this should cost about the same as the small case, not scale
+	// with the body.
+	{"large_body_without_template_key", "<!-- title: Hi -->\n" + largeBody},
 }
 
 func BenchmarkPageOptsOutOfTemplating(b *testing.B) {
-	for name, input := range pageOptsOutOfTemplatingInputs {
-		in := []byte(input)
-		b.Run(name, func(b *testing.B) {
+	for _, tt := range pageOptsOutOfTemplatingInputs {
+		in := []byte(tt.input)
+		b.Run(tt.name, func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
 				pageOptsOutOfTemplating(in)
+			}
+		})
+	}
+}
+
+// newRenderBenchGenerator is newRenderTestGenerator's benchmark
+// counterpart: testing.B embeds the same TempDir/Chdir support as
+// testing.T, so this builds an identical minimal Generator without
+// depending on a *testing.T.
+func newRenderBenchGenerator(b *testing.B) *Generator {
+	b.Helper()
+	b.Chdir(b.TempDir())
+	if err := os.MkdirAll("deploy", 0o755); err != nil {
+		b.Fatal(err)
+	}
+	gen := &Generator{
+		Config: ConfigSection{"zas": ConfigSection{"deploy": "deploy"}},
+		I18n:   &gt.Build{Index: gt.Strings{}, Origin: "en"},
+	}
+	layout, err := thtml.New("layout").Funcs(helpers).Parse(`<body>{{.Body}}</body>`)
+	if err != nil {
+		b.Fatal(err)
+	}
+	gen.Layout = layout
+	return gen
+}
+
+// renderInputs are whole-page render() inputs standing in for a realistic
+// page mix, so the win from skipping text/template on a page with no "{{"
+// - invisible to a pageOptsOutOfTemplating-only benchmark, since it never
+// gets called at all on that path - shows up here instead. Each shape has
+// a small and a large variant: render's fixed per-call costs (HTML5 parse,
+// the atomic write) dominate the large ones, so the small ones are what
+// actually isolates the string(input) copy and parse/execute round trip
+// this change avoids.
+var renderInputs = []struct {
+	name  string
+	input string
+}{
+	// The common shape this change targets: a title comment, no template
+	// actions anywhere. Never reaches pageOptsOutOfTemplating at all.
+	{"plain_page/small", "<!-- title: Hi -->\n<h1>Hi</h1>"},
+	{"plain_page/large", "<!-- title: Hi -->\n" + largeBody},
+	// Actually uses template syntax, so the parse/execute path still
+	// runs - benchmarked so a regression there would show.
+	{"templated_page/small", "<!-- title: Hi -->\n<h1>{{.Path}}</h1>"},
+	{"templated_page/large", "<!-- title: Hi -->\n<h1>{{.Path}}</h1>\n" + largeBody},
+	// Explicitly opted out via "template: false" and full of literal
+	// "{{" - the shape the opt-out exists for (Go-template documentation,
+	// a Vue/Handlebars snippet), and the case that pays pageOptsOutOfTemplating's
+	// real yaml.Unmarshal every time.
+	{"opted_out_page/small", "<!-- template: false -->\n<h1>{{ message }}</h1>"},
+	{"opted_out_page/large", "<!-- template: false -->\n<h1>{{ message }}</h1>\n" + largeBody},
+}
+
+func BenchmarkRender(b *testing.B) {
+	for _, tt := range renderInputs {
+		in := []byte(tt.input)
+		b.Run(tt.name, func(b *testing.B) {
+			gen := newRenderBenchGenerator(b)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := gen.render("page.html", in); err != nil {
+					b.Fatal(err)
+				}
 			}
 		})
 	}

--- a/raw_page_bench_test.go
+++ b/raw_page_bench_test.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2013 Dario Castañé.
+ * This file is part of Zas.
+ *
+ * Zas is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Zas is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Zas.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package zas
+
+import (
+	"strings"
+	"testing"
+)
+
+// pageOptsOutOfTemplatingInputs are representative render() inputs:
+// pageOptsOutOfTemplating runs once per source file on every render() call,
+// so it needs to stay cheap regardless of how big the rest of the page is.
+var pageOptsOutOfTemplatingInputs = map[string]string{
+	"small_with_comment":  "<!-- title: Hi -->\n<h1>Hi</h1>",
+	"large_body_no_match": "<!-- title: Hi -->\n<h1>Hi</h1>" + strings.Repeat("<p>filler paragraph content</p>\n", 2000),
+	"no_comment_at_all":   strings.Repeat("<p>filler paragraph content</p>\n", 2000),
+}
+
+func BenchmarkPageOptsOutOfTemplating(b *testing.B) {
+	for name, input := range pageOptsOutOfTemplatingInputs {
+		in := []byte(input)
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				pageOptsOutOfTemplating(in)
+			}
+		})
+	}
+}

--- a/raw_page_test.go
+++ b/raw_page_test.go
@@ -28,6 +28,17 @@ import (
 	"github.com/melvinmt/gt"
 )
 
+// utf16leBOM prepends a UTF-16LE byte-order mark and encodes s as
+// UTF-16LE, reproducing the shape yaml.v2 transcodes internally - see the
+// "utf-16le comment body still opts out" case below and mayDefineTemplateKey.
+func utf16leBOM(s string) string {
+	out := []byte("\xff\xfe")
+	for _, r := range s {
+		out = append(out, byte(r), 0)
+	}
+	return string(out)
+}
+
 // Every page used to be unconditionally parsed and executed as a
 // text/template, with no way to opt out: a file containing literal {{ }}
 // that isn't valid template syntax (e.g. `{{ message }}`, documenting Zas's
@@ -87,6 +98,47 @@ func TestPageOptsOutOfTemplating(t *testing.T) {
 		{
 			name:  "template false later in the document doesn't count",
 			input: "<h1>Hi</h1>\n<!-- template: false -->",
+			want:  false,
+		},
+		// The remaining cases pin mayDefineTemplateKey's guards: each one
+		// is a real yaml.v2 construct that can decode to a "template" key
+		// without spelling the literal bytes "template" in the comment,
+		// found while proving the fast path can't just check for those
+		// bytes and a backslash. Deleting the '!' or BOM guard would make
+		// the "still opts out" cases below silently stop opting out.
+		{
+			name:  "!!binary-tagged key still opts out",
+			input: "<!-- !!binary dGVtcGxhdGU=: false -->\n<h1>Hi</h1>",
+			want:  true,
+		},
+		{
+			name:  "double-quoted escaped key still opts out",
+			input: `<!-- "\x74emplate": false -->` + "\n<h1>Hi</h1>",
+			want:  true,
+		},
+		{
+			name:  "utf-16le comment body still opts out",
+			input: "<!--" + utf16leBOM("template: false") + "-->\n<h1>Hi</h1>",
+			want:  true,
+		},
+		{
+			name:  "capitalized Template is not an opt-out",
+			input: "<!-- Template: false -->\n<h1>Hi</h1>",
+			want:  false,
+		},
+		{
+			name:  "template only inside a value stays an opt-in",
+			input: "<!-- title: Template gallery -->\n<h1>Hi</h1>",
+			want:  false,
+		},
+		{
+			name:  "exclamation mark in an unrelated value",
+			input: "<!-- title: Hi! -->\n<h1>Hi</h1>",
+			want:  false,
+		},
+		{
+			name:  "backslash in an unrelated value",
+			input: `<!-- title: C:\docs -->` + "\n<h1>Hi</h1>",
 			want:  false,
 		},
 	}

--- a/raw_page_test.go
+++ b/raw_page_test.go
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2013 Dario Castañé.
+ * This file is part of Zas.
+ *
+ * Zas is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Zas is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Zas.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package zas
+
+import (
+	thtml "html/template"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/melvinmt/gt"
+)
+
+// Every page used to be unconditionally parsed and executed as a
+// text/template, with no way to opt out: a file containing literal {{ }}
+// that isn't valid template syntax (e.g. `{{ message }}`, documenting Zas's
+// own template syntax, or a Vue/Angular/Handlebars snippet using the same
+// delimiters) failed the whole page with a template parse/execute error,
+// and one that happened to parse as valid Go template syntax was silently
+// executed against live data instead of shown literally. These tests cover
+// pageOptsOutOfTemplating directly, then render() and the full Generator.Run
+// pipeline for the "template: false" opt-out it implements.
+
+func TestPageOptsOutOfTemplating(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			name:  "no comment at all",
+			input: "<h1>Hi</h1>",
+			want:  false,
+		},
+		{
+			name:  "comment without a template key",
+			input: "<!-- title: Hi -->\n<h1>Hi</h1>",
+			want:  false,
+		},
+		{
+			name:  "template explicitly true",
+			input: "<!-- template: true -->\n<h1>Hi</h1>",
+			want:  false,
+		},
+		{
+			name:  "template false",
+			input: "<!-- template: false -->\n<h1>Hi</h1>",
+			want:  true,
+		},
+		{
+			name:  "template false alongside other keys",
+			input: "<!--\ntitle: Hi\ntemplate: false\n-->\n<h1>Hi</h1>",
+			want:  true,
+		},
+		{
+			name:  "template false past a leading doctype",
+			input: "<!DOCTYPE html>\n<!-- template: false -->\n<h1>Hi</h1>",
+			want:  true,
+		},
+		{
+			name:  "template false past leading whitespace",
+			input: "\n\n  <!-- template: false -->\n<h1>Hi</h1>",
+			want:  true,
+		},
+		{
+			name:  "malformed YAML comment is not an opt-out",
+			input: "<!-- language: ru\n\tbad: true\n-->\n<h1>Hi</h1>",
+			want:  false,
+		},
+		{
+			name:  "template false later in the document doesn't count",
+			input: "<h1>Hi</h1>\n<!-- template: false -->",
+			want:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pageOptsOutOfTemplating([]byte(tt.input)); got != tt.want {
+				t.Errorf("pageOptsOutOfTemplating(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// Without the opt-out, a page containing {{ message }} - the exact
+// reproduction case: text that looks like a template action but isn't one
+// Zas defines - fails the whole render with a template parse/execute error.
+func TestRenderWithoutMarkerFailsOnUndefinedTemplateFunction(t *testing.T) {
+	gen := newRenderTestGenerator(t)
+	src := "<p>{{ message }}</p>"
+
+	if err := gen.render("page.html", []byte(src)); err == nil {
+		t.Fatal("render() error = nil, want a template error for undefined function \"message\"")
+	}
+}
+
+// With the opt-out, the same content renders successfully and the literal
+// {{ message }} text survives unexecuted into the deploy output.
+func TestRenderWithMarkerSkipsTemplatingAndKeepsLiteralBraces(t *testing.T) {
+	gen := newRenderTestGenerator(t)
+	src := "<!-- template: false -->\n<p>{{ message }}</p>"
+
+	if err := gen.render("page.html", []byte(src)); err != nil {
+		t.Fatalf("render() error = %v, want nil", err)
+	}
+	out := readRenderedFile(t, "page.html")
+	if !strings.Contains(out, "{{ message }}") {
+		t.Fatalf("deploy output = %q, want it to contain the literal %q", out, "{{ message }}")
+	}
+}
+
+// A page without the marker keeps being templated exactly as before: this
+// is the regression check that the opt-out doesn't disable templating
+// globally.
+func TestRenderWithoutMarkerStillExecutesTemplate(t *testing.T) {
+	gen := newRenderTestGenerator(t)
+	src := "<p>{{.Path}}</p>"
+
+	if err := gen.render("page.html", []byte(src)); err != nil {
+		t.Fatalf("render() error = %v, want nil", err)
+	}
+	out := readRenderedFile(t, "page.html")
+	if !strings.Contains(out, "/page.html") {
+		t.Fatalf("deploy output = %q, want {{.Path}} substituted with /page.html", out)
+	}
+	if strings.Contains(out, "{{.Path}}") {
+		t.Fatalf("deploy output = %q, want no literal {{.Path}} left over", out)
+	}
+}
+
+// A raw page's other page-config fields (e.g. title) still work: only
+// text/template execution is skipped, extractPageConfig and the rest of the
+// pipeline run exactly as for any other page.
+func TestRenderWithMarkerStillAppliesPageTitle(t *testing.T) {
+	gen := newRenderTestGeneratorWithTitleLayout(t)
+	// {{ undefinedFunc }} in the body proves templating was actually
+	// skipped (it would fail template.Parse otherwise), while title still
+	// comes from the very same config comment via extractPageConfig.
+	src := "<!--\ntitle: Custom\ntemplate: false\n-->\n<h1>{{ undefinedFunc }}</h1>"
+
+	if err := gen.render("page.html", []byte(src)); err != nil {
+		t.Fatalf("render() error = %v, want nil", err)
+	}
+	out := readRenderedFile(t, "page.html")
+	if !strings.Contains(out, "<title>Custom</title>") {
+		t.Fatalf("deploy output = %q, want it to contain %q", out, "<title>Custom</title>")
+	}
+	if !strings.Contains(out, "{{ undefinedFunc }}") {
+		t.Fatalf("deploy output = %q, want the literal %q preserved", out, "{{ undefinedFunc }}")
+	}
+}
+
+// readRenderedFile reads rel from the "deploy" directory newRenderTestGenerator
+// and newRenderTestGeneratorWithTitleLayout write into.
+func readRenderedFile(t *testing.T, rel string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("deploy", rel))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+// newRenderTestGeneratorWithTitleLayout is like newRenderTestGenerator, but
+// its layout also renders {{.Title}}, so a test can confirm a page's own
+// title config comment still reaches the deploy output.
+func newRenderTestGeneratorWithTitleLayout(t *testing.T) *Generator {
+	t.Helper()
+	t.Chdir(t.TempDir())
+	if err := os.MkdirAll("deploy", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gen := &Generator{
+		Config: ConfigSection{"zas": ConfigSection{"deploy": "deploy"}},
+		I18n:   &gt.Build{Index: gt.Strings{}, Origin: "en"},
+	}
+	layout, err := thtml.New("layout").Funcs(helpers).Parse(`<head><title>{{.Title}}</title></head><body>{{.Body}}</body>`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gen.Layout = layout
+	return gen
+}
+
+// TestGenerateRawPageSkipsTemplating drives the full Generator.Run pipeline
+// against testdata/site/raw.md, the exact reproduction case: a fenced code
+// block containing literal {{ message }}. It must now build successfully
+// (it used to fail the whole file with a template parse error) with the
+// literal braces preserved in the deploy output, while the rest of the site
+// - including pages that still rely on real template execution - is
+// unaffected.
+func TestGenerateRawPageSkipsTemplating(t *testing.T) {
+	newTestSite(t, "site")
+	if err := generate(t); err != nil {
+		t.Fatalf("generate() error = %v, want nil", err)
+	}
+	out := readDeploy(t, "raw.html")
+	if !strings.Contains(out, "{{ message }}") {
+		t.Fatalf("raw.html = %q, want it to contain the literal %q", out, "{{ message }}")
+	}
+	if !strings.Contains(out, "<title>Raw</title>") {
+		t.Fatalf("raw.html = %q, want it to contain %q (page config still applied)", out, "<title>Raw</title>")
+	}
+
+	// A normal page's real template syntax - the layout's own {{.Title}} -
+	// must still be executed, confirming the opt-out is scoped to raw.md
+	// and doesn't disable templating globally.
+	index := readDeploy(t, "index.html")
+	if !strings.Contains(index, "<title>Home</title>") {
+		t.Fatalf("index.html = %q, want %q (unrelated page still templated normally)", index, "<title>Home</title>")
+	}
+}

--- a/testdata/site/raw.md
+++ b/testdata/site/raw.md
@@ -1,0 +1,11 @@
+<!--
+title: Raw
+template: false
+-->
+# Raw
+
+Zas's own template syntax, shown here literally instead of executed:
+
+```text
+{{ message }}
+```


### PR DESCRIPTION
## Summary

- Every page is currently parsed and executed as a `text/template` with no way to mark it "raw": a file containing literal `{{ }}` that isn't valid template syntax (a Vue/Angular/Handlebars snippet, Go-template documentation, or a code sample showing off Zas's own template syntax) fails the whole render with a parse/execute error; one that happens to parse as valid Go template syntax gets silently executed against live data instead of shown literally.
- A page can now set `template: false` in its config comment to skip `text/template` parsing/execution entirely; its content, including any `{{ }}` it contains, flows through unexecuted into the rest of the pipeline exactly as any other page's bytes would.
- The existing `extractPageConfig` mechanism (used for other page-config flags) can't gate this, since `render()` parses/executes the page as a template *before* the HTML5 parse that produces the document `extractPageConfig` reads from. Instead, a small regex pulls the leading config comment straight out of the raw source bytes and YAML-decodes just that snippet, before `ttext.New(...).Parse` ever runs. The comment itself is left untouched when a page opts out, so `extractPageConfig` still parses it normally further down the pipeline — `title`, `language`, and any other page-config field keep working on a raw page exactly as before.
- `testdata/site/raw.md` carries the new flag as a live example (matching the exact reproduction case: a fenced code block containing `{{ message }}`), and the README's template section documents the new key.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .`, `golangci-lint run ./...` all clean
- [x] `go test -race -count=1 ./...` passes
- [x] New unit tests for `pageOptsOutOfTemplating` (leading comment detection, doctype tolerance, malformed YAML, marker elsewhere in the doc not counting)
- [x] New `render()`-level tests: a page without the marker still fails on undefined template functions (regression baseline), a page with the marker skips templating and keeps literal `{{ }}`, a page without the marker still executes real template syntax, and a raw page's own `title` config still applies
- [x] New e2e test (`TestGenerateRawPageSkipsTemplating`) driving the full `Generator.Run` pipeline against `testdata/site/raw.md`, confirming it now builds successfully with literal `{{ message }}` preserved, while an unrelated page's real `{{.Title}}` templating stays unaffected
- [x] Live repro: built the `zas` binary, ran `zas generate` against a fixture site with a `template: false` page (`{{ message }}` in a code block) and a normal page (`{{.Path}}` and `{{.Title}}` via layout) — raw page built successfully with the literal preserved, normal page's templating substituted correctly; confirmed the same page *without* the marker still fails the whole build with `template: current:2: function "message" not defined`