### PR TITLE
perf(generate): scan the leading config comment by hand, not regexp

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -784,6 +784,73 @@ func hasFoldPrefix(b []byte, prefix string) bool {
 	return true
 }
 
+// templateKey is the one map key pageOptsOutOfTemplating cares about.
+// bomUTF16LE/bomUTF16BE are the two byte-order marks yaml.v2 recognizes at
+// the very start of a stream - see mayDefineTemplateKey, the only place
+// either is used.
+var templateKey = []byte("template")
+
+const (
+	bomUTF16LE = "\xff\xfe"
+	bomUTF16BE = "\xfe\xff"
+)
+
+// mayDefineTemplateKey reports whether content could possibly decode to a
+// YAML mapping containing the exact key "template", without actually
+// running the parser to find out. It exists to keep yaml.Unmarshal off the
+// hot path: gopkg.in/yaml.v2's yaml_parser_initialize allocates the
+// parser's two I/O buffers (512 and 1536 bytes) on every single Unmarshal
+// call regardless of input size, so asking an eleven-byte
+// "<!-- title: Hi -->" comment for a key it doesn't have costs ~4.5us and
+// ~5.5KB - once per page, on every render, across renderConcurrency()
+// goroutines.
+//
+// A false positive here only costs the yaml parse that would have run
+// anyway, so the bar is one-sided: this must never say false for content
+// yaml would in fact decode with a "template" key. Every YAML 1.1
+// construct that can put a key into the map either reproduces that key's
+// bytes verbatim or needs one of the three markers checked below - verified
+// against gopkg.in/yaml.v2 v2.4.0's actual source, not just the spec:
+//
+//   - Plain and single-quoted scalars reproduce their bytes. A line break
+//     inside one folds to a space, so "temp\nlate" decodes as "temp late"
+//     and can never be rejoined into "template"; block scalars (| and >),
+//     explicit "? " keys and flow mappings are just other ways to spell
+//     those same bytes. Anchors, aliases and "<<" merge keys can only
+//     reach a key some node in this very document already spells out, and
+//     yaml.Unmarshal is handed nothing but the comment's own bytes.
+//   - A double-quoted scalar can synthesize the key ("\x74emplate", or a
+//     backslash-newline continuation joining "temp" and "late"), but every
+//     such form needs a backslash.
+//   - So can a tag: yaml.v2 base64-decodes !!binary into a Go string
+//     (decode.go's scalar case deliberately excludes yaml_BINARY_TAG from
+//     resolvableTag in resolve.go, so it skips normal resolution and hits
+//     the base64 branch instead), which makes
+//     "<!-- !!binary dGVtcGxhdGU=: false -->" - base64 of "template" - a
+//     real opt-out today that never spells the key in the comment. Every
+//     way to name that tag - the !! shorthand, a verbatim !<...>, or a
+//     %TAG-remapped handle - puts a '!' somewhere in the document, because
+//     a tag handle is delimited by them.
+//   - The bytes need not be UTF-8 at all. yaml.v2 sniffs a UTF-16 byte
+//     order mark and transcodes (readerc.go's
+//     yaml_parser_determine_encoding), so a comment body opening with
+//     FF FE spells the key as 74 00 65 00 ... instead of literal ASCII.
+//     That sniff happens once, at the very start of the stream and
+//     nowhere else, so a two-byte prefix check is exact rather than
+//     another scan.
+//
+// The key is matched case-sensitively on purpose: the lookup this feeds is
+// config["template"], an exact Go string comparison, so "Template: false"
+// is not an opt-out today and must not become one here.
+func mayDefineTemplateKey(content []byte) bool {
+	if hasPrefix(content, bomUTF16LE) || hasPrefix(content, bomUTF16BE) {
+		return true
+	}
+	return bytes.Contains(content, templateKey) ||
+		bytes.IndexByte(content, '\\') >= 0 ||
+		bytes.IndexByte(content, '!') >= 0
+}
+
 // pageOptsOutOfTemplating reports whether input's leading config comment
 // sets "template: false", letting a whole page skip text/template
 // parsing/execution so its content - including any literal {{ }} it
@@ -807,6 +874,12 @@ func pageOptsOutOfTemplating(input []byte) bool {
 	if !ok {
 		return false
 	}
+	if !mayDefineTemplateKey(content) {
+		// yaml could only confirm what the scan above already
+		// established, and it is by far the most expensive thing this
+		// function does - see mayDefineTemplateKey.
+		return false
+	}
 	var config map[interface{}]interface{}
 	if err := yaml.Unmarshal(content, &config); err != nil {
 		return false
@@ -814,6 +887,18 @@ func pageOptsOutOfTemplating(input []byte) bool {
 	runTemplate, ok := config["template"].(bool)
 	return ok && !runTemplate
 }
+
+// templateActionOpen is text/template's default left delimiter, and the
+// only one render's template ever uses - nothing in this repo calls
+// ttext.New(...).Delims(...). A page containing no "{{" anywhere therefore
+// has no template actions at all: not a "{{- -}}" trim marker, not a
+// "{{/* */}}" comment, since text/template's lexer (lexText in
+// text/template/parse/lex.go) only reaches either past this same
+// delimiter. With none present, Parse builds a tree holding a single text
+// node and Execute copies it back out byte for byte - so render's
+// no-templating branch below produces the identical result without paying
+// for string(input)'s full-file copy or the parse/execute round trip.
+var templateActionOpen = []byte("{{")
 
 /*
  * Generic render function. It expects input to be a valid HTML document.
@@ -825,7 +910,18 @@ func (gen *Generator) render(path string, input []byte) (err error) {
 	// Building context and rendering template.
 	data := NewZasData(path, gen)
 	data.Directory, _, _ = gen.loadZasDirectoryConfig(path)
-	if pageOptsOutOfTemplating(input) {
+	// The "{{" check goes first, and that order is load-bearing rather
+	// than stylistic: when input has no "{{" at all, templating and the
+	// opt-out branch below produce byte-identical output regardless of
+	// what the page's config comment says, so pageOptsOutOfTemplating's
+	// answer cannot change the outcome, and || short-circuits it away
+	// entirely. That matters because mayDefineTemplateKey's guards are
+	// deliberately one-sided (an innocuous "!" or backslash anywhere in
+	// the comment - "Hi!", a Windows path in a title - still falls
+	// through to a real yaml.Unmarshal); putting bytes.Contains first
+	// means a plain page never pays for that parse over a question whose
+	// answer was never going to matter.
+	if !bytes.Contains(input, templateActionOpen) || pageOptsOutOfTemplating(input) {
 		// input flows through unchanged: no text/template parsing or
 		// execution at all, so a literal {{ }} anywhere in it - including
 		// inside a fenced code block - survives verbatim into the rest of

--- a/generate.go
+++ b/generate.go
@@ -685,7 +685,18 @@ func (gen *Generator) setCachedDirConfig(path string, entry dirConfigEntry) {
 	gen.cachedZasDirectoryConfigs[path] = entry
 }
 
-// pageConfigCommentRe extracts a page's leading config comment straight
+// doctypePrefix and commentOpen/commentClose are the literal delimiters
+// leadingConfigComment scans for. Matching regexp's (?is) \s class exactly,
+// not unicode.IsSpace, is what makes isConfigSpace its own function below
+// rather than a reuse of a stdlib whitespace check.
+const (
+	doctypePrefix = "<!DOCTYPE"
+	commentOpen   = "<!--"
+)
+
+var commentClose = []byte("-->")
+
+// leadingConfigComment extracts a page's leading config comment straight
 // from its raw source bytes, tolerating a single leading <!DOCTYPE ...>
 // ahead of it (the same tolerance extractPageConfig has once the document
 // is fully HTML5-parsed) and any whitespace before either. It exists only
@@ -693,7 +704,85 @@ func (gen *Generator) setCachedDirConfig(path string, entry dirConfigEntry) {
 // whether it should run at all - see that function and the comment on
 // render's ttext.New call below for why extractPageConfig itself can't be
 // used for this.
-var pageConfigCommentRe = regexp.MustCompile(`(?is)\A\s*(?:<!DOCTYPE[^>]*>\s*)?<!--(.*?)-->`)
+//
+// It walks input by hand as a small state machine - skip whitespace, try
+// an optional doctype, skip whitespace again, require the comment to open
+// immediately, then scan for its close - instead of using regexp, since
+// this runs once per source file on every render() call and is on the hot
+// path for a large site. It reproduces
+// `(?is)\A\s*(?:<!DOCTYPE[^>]*>\s*)?<!--(.*?)-->` byte for byte: in
+// particular the scan for "-->" stops at the *first* occurrence (a later
+// comment further into input must never count), and any mismatch anchored
+// at the very start of input - after whitespace/doctype - means there is
+// no leading comment at all.
+func leadingConfigComment(input []byte) ([]byte, bool) {
+	i := skipConfigSpace(input, 0)
+	if hasFoldPrefix(input[i:], doctypePrefix) {
+		end := bytes.IndexByte(input[i:], '>')
+		if end < 0 {
+			// No closing '>' for the doctype: the optional group can't
+			// have matched, but input at i still starts with "<!DOCTYPE",
+			// which can never also start with "<!--", so there is no
+			// leading comment either way.
+			return nil, false
+		}
+		i += end + 1
+		i = skipConfigSpace(input, i)
+	}
+	if !hasPrefix(input[i:], commentOpen) {
+		return nil, false
+	}
+	i += len(commentOpen)
+	end := bytes.Index(input[i:], commentClose)
+	if end < 0 {
+		return nil, false
+	}
+	return input[i : i+end], true
+}
+
+// skipConfigSpace advances i past any run of configSpace bytes.
+func skipConfigSpace(input []byte, i int) int {
+	for i < len(input) && isConfigSpace(input[i]) {
+		i++
+	}
+	return i
+}
+
+// isConfigSpace reports whether b is one of regexp's \s bytes
+// ([\t\n\f\r ]), matching the whitespace class the original
+// pageConfigCommentRe relied on exactly.
+func isConfigSpace(b byte) bool {
+	switch b {
+	case '\t', '\n', '\f', '\r', ' ':
+		return true
+	}
+	return false
+}
+
+// hasPrefix reports whether b starts with prefix. Comparing a sliced
+// []byte-to-string conversion with == is a case the compiler recognizes
+// and doesn't allocate for.
+func hasPrefix(b []byte, prefix string) bool {
+	return len(b) >= len(prefix) && string(b[:len(prefix)]) == prefix
+}
+
+// hasFoldPrefix is hasPrefix's ASCII case-insensitive counterpart, used
+// only for the (case-insensitive) "<!DOCTYPE" tag.
+func hasFoldPrefix(b []byte, prefix string) bool {
+	if len(b) < len(prefix) {
+		return false
+	}
+	for i := 0; i < len(prefix); i++ {
+		c := b[i]
+		if 'a' <= c && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		if c != prefix[i] {
+			return false
+		}
+	}
+	return true
+}
 
 // pageOptsOutOfTemplating reports whether input's leading config comment
 // sets "template: false", letting a whole page skip text/template
@@ -714,12 +803,12 @@ var pageConfigCommentRe = regexp.MustCompile(`(?is)\A\s*(?:<!DOCTYPE[^>]*>\s*)?<
 // the page reaches it further down the pipeline, so it doesn't need to be
 // reported twice.
 func pageOptsOutOfTemplating(input []byte) bool {
-	m := pageConfigCommentRe.FindSubmatch(input)
-	if m == nil {
+	content, ok := leadingConfigComment(input)
+	if !ok {
 		return false
 	}
 	var config map[interface{}]interface{}
-	if err := yaml.Unmarshal(m[1], &config); err != nil {
+	if err := yaml.Unmarshal(content, &config); err != nil {
 		return false
 	}
 	runTemplate, ok := config["template"].(bool)

--- a/raw_page_bench_test.go
+++ b/raw_page_bench_test.go
@@ -19,26 +19,123 @@
 package zas
 
 import (
+	thtml "html/template"
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/melvinmt/gt"
 )
 
-// pageOptsOutOfTemplatingInputs are representative render() inputs:
+// largeBody is the body every "large" case below shares: big enough that a
+// full-input scan is measurable, and identical across cases so the only
+// variable being benchmarked is the leading comment.
+var largeBody = "<h1>Hi</h1>\n" + strings.Repeat("<p>filler paragraph content</p>\n", 2000)
+
+// pageOptsOutOfTemplatingInputs are representative render() inputs, a slice
+// (not a map) so benchstat output has a stable order to diff against.
 // pageOptsOutOfTemplating runs once per source file on every render() call,
-// so it needs to stay cheap regardless of how big the rest of the page is.
-var pageOptsOutOfTemplatingInputs = map[string]string{
-	"small_with_comment":  "<!-- title: Hi -->\n<h1>Hi</h1>",
-	"large_body_no_match": "<!-- title: Hi -->\n<h1>Hi</h1>" + strings.Repeat("<p>filler paragraph content</p>\n", 2000),
-	"no_comment_at_all":   strings.Repeat("<p>filler paragraph content</p>\n", 2000),
+// so it needs to stay cheap regardless of what its comment looks like or
+// how big the rest of the page is.
+var pageOptsOutOfTemplatingInputs = []struct {
+	name  string
+	input string
+}{
+	// No leading comment: leadingConfigComment rejects on the very first
+	// byte, so neither the key scan nor yaml ever runs.
+	{"no_comment", "<h1>Hi</h1>"},
+	// The ordinary case every ordinary page hits: a comment that sets
+	// title/language but never mentions "template" - this is the shape
+	// mayDefineTemplateKey exists to keep off the yaml.Unmarshal path.
+	{"comment_without_template_key", "<!-- title: Hi -->\n<h1>Hi</h1>"},
+	// A comment that really does carry the key, so the scan can't rule it
+	// out and yaml still has to run - the case this change doesn't speed
+	// up, benchmarked so a regression there would show.
+	{"comment_with_template_key", "<!-- template: false -->\n<h1>Hi</h1>"},
+	// A backslash defeats the scan's guard even with no "template" key
+	// present, so this pays a full yaml parse it didn't strictly need -
+	// the deliberate, documented cost of keeping the scan provably exact.
+	{"comment_with_backslash", `<!-- title: C:\docs -->` + "\n<h1>Hi</h1>"},
+	// Same shape as comment_without_template_key, but with a large body
+	// after the comment: leadingConfigComment stops at the first "-->",
+	// so this should cost about the same as the small case, not scale
+	// with the body.
+	{"large_body_without_template_key", "<!-- title: Hi -->\n" + largeBody},
 }
 
 func BenchmarkPageOptsOutOfTemplating(b *testing.B) {
-	for name, input := range pageOptsOutOfTemplatingInputs {
-		in := []byte(input)
-		b.Run(name, func(b *testing.B) {
+	for _, tt := range pageOptsOutOfTemplatingInputs {
+		in := []byte(tt.input)
+		b.Run(tt.name, func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
 				pageOptsOutOfTemplating(in)
+			}
+		})
+	}
+}
+
+// newRenderBenchGenerator is newRenderTestGenerator's benchmark
+// counterpart: testing.B embeds the same TempDir/Chdir support as
+// testing.T, so this builds an identical minimal Generator without
+// depending on a *testing.T.
+func newRenderBenchGenerator(b *testing.B) *Generator {
+	b.Helper()
+	b.Chdir(b.TempDir())
+	if err := os.MkdirAll("deploy", 0o755); err != nil {
+		b.Fatal(err)
+	}
+	gen := &Generator{
+		Config: ConfigSection{"zas": ConfigSection{"deploy": "deploy"}},
+		I18n:   &gt.Build{Index: gt.Strings{}, Origin: "en"},
+	}
+	layout, err := thtml.New("layout").Funcs(helpers).Parse(`<body>{{.Body}}</body>`)
+	if err != nil {
+		b.Fatal(err)
+	}
+	gen.Layout = layout
+	return gen
+}
+
+// renderInputs are whole-page render() inputs standing in for a realistic
+// page mix, so the win from skipping text/template on a page with no "{{"
+// - invisible to a pageOptsOutOfTemplating-only benchmark, since it never
+// gets called at all on that path - shows up here instead. Each shape has
+// a small and a large variant: render's fixed per-call costs (HTML5 parse,
+// the atomic write) dominate the large ones, so the small ones are what
+// actually isolates the string(input) copy and parse/execute round trip
+// this change avoids.
+var renderInputs = []struct {
+	name  string
+	input string
+}{
+	// The common shape this change targets: a title comment, no template
+	// actions anywhere. Never reaches pageOptsOutOfTemplating at all.
+	{"plain_page/small", "<!-- title: Hi -->\n<h1>Hi</h1>"},
+	{"plain_page/large", "<!-- title: Hi -->\n" + largeBody},
+	// Actually uses template syntax, so the parse/execute path still
+	// runs - benchmarked so a regression there would show.
+	{"templated_page/small", "<!-- title: Hi -->\n<h1>{{.Path}}</h1>"},
+	{"templated_page/large", "<!-- title: Hi -->\n<h1>{{.Path}}</h1>\n" + largeBody},
+	// Explicitly opted out via "template: false" and full of literal
+	// "{{" - the shape the opt-out exists for (Go-template documentation,
+	// a Vue/Handlebars snippet), and the case that pays pageOptsOutOfTemplating's
+	// real yaml.Unmarshal every time.
+	{"opted_out_page/small", "<!-- template: false -->\n<h1>{{ message }}</h1>"},
+	{"opted_out_page/large", "<!-- template: false -->\n<h1>{{ message }}</h1>\n" + largeBody},
+}
+
+func BenchmarkRender(b *testing.B) {
+	for _, tt := range renderInputs {
+		in := []byte(tt.input)
+		b.Run(tt.name, func(b *testing.B) {
+			gen := newRenderBenchGenerator(b)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := gen.render("page.html", in); err != nil {
+					b.Fatal(err)
+				}
 			}
 		})
 	}

--- a/raw_page_bench_test.go
+++ b/raw_page_bench_test.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2013 Dario Castañé.
+ * This file is part of Zas.
+ *
+ * Zas is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Zas is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Zas.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package zas
+
+import (
+	"strings"
+	"testing"
+)
+
+// pageOptsOutOfTemplatingInputs are representative render() inputs:
+// pageOptsOutOfTemplating runs once per source file on every render() call,
+// so it needs to stay cheap regardless of how big the rest of the page is.
+var pageOptsOutOfTemplatingInputs = map[string]string{
+	"small_with_comment":  "<!-- title: Hi -->\n<h1>Hi</h1>",
+	"large_body_no_match": "<!-- title: Hi -->\n<h1>Hi</h1>" + strings.Repeat("<p>filler paragraph content</p>\n", 2000),
+	"no_comment_at_all":   strings.Repeat("<p>filler paragraph content</p>\n", 2000),
+}
+
+func BenchmarkPageOptsOutOfTemplating(b *testing.B) {
+	for name, input := range pageOptsOutOfTemplatingInputs {
+		in := []byte(input)
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				pageOptsOutOfTemplating(in)
+			}
+		})
+	}
+}

--- a/raw_page_test.go
+++ b/raw_page_test.go
@@ -28,6 +28,17 @@ import (
 	"github.com/melvinmt/gt"
 )
 
+// utf16leBOM prepends a UTF-16LE byte-order mark and encodes s as
+// UTF-16LE, reproducing the shape yaml.v2 transcodes internally - see the
+// "utf-16le comment body still opts out" case below and mayDefineTemplateKey.
+func utf16leBOM(s string) string {
+	out := []byte("\xff\xfe")
+	for _, r := range s {
+		out = append(out, byte(r), 0)
+	}
+	return string(out)
+}
+
 // Every page used to be unconditionally parsed and executed as a
 // text/template, with no way to opt out: a file containing literal {{ }}
 // that isn't valid template syntax (e.g. `{{ message }}`, documenting Zas's
@@ -87,6 +98,47 @@ func TestPageOptsOutOfTemplating(t *testing.T) {
 		{
 			name:  "template false later in the document doesn't count",
 			input: "<h1>Hi</h1>\n<!-- template: false -->",
+			want:  false,
+		},
+		// The remaining cases pin mayDefineTemplateKey's guards: each one
+		// is a real yaml.v2 construct that can decode to a "template" key
+		// without spelling the literal bytes "template" in the comment,
+		// found while proving the fast path can't just check for those
+		// bytes and a backslash. Deleting the '!' or BOM guard would make
+		// the "still opts out" cases below silently stop opting out.
+		{
+			name:  "!!binary-tagged key still opts out",
+			input: "<!-- !!binary dGVtcGxhdGU=: false -->\n<h1>Hi</h1>",
+			want:  true,
+		},
+		{
+			name:  "double-quoted escaped key still opts out",
+			input: `<!-- "\x74emplate": false -->` + "\n<h1>Hi</h1>",
+			want:  true,
+		},
+		{
+			name:  "utf-16le comment body still opts out",
+			input: "<!--" + utf16leBOM("template: false") + "-->\n<h1>Hi</h1>",
+			want:  true,
+		},
+		{
+			name:  "capitalized Template is not an opt-out",
+			input: "<!-- Template: false -->\n<h1>Hi</h1>",
+			want:  false,
+		},
+		{
+			name:  "template only inside a value stays an opt-in",
+			input: "<!-- title: Template gallery -->\n<h1>Hi</h1>",
+			want:  false,
+		},
+		{
+			name:  "exclamation mark in an unrelated value",
+			input: "<!-- title: Hi! -->\n<h1>Hi</h1>",
+			want:  false,
+		},
+		{
+			name:  "backslash in an unrelated value",
+			input: `<!-- title: C:\docs -->` + "\n<h1>Hi</h1>",
 			want:  false,
 		},
 	}


### PR DESCRIPTION
## Summary

Builds on #66. Two commits, each cutting a different cost off `render`'s per-page hot path.

### 1. Regexp → hand-written FSM (`pageConfigCommentRe` → `leadingConfigComment`)

`pageOptsOutOfTemplating` has to inspect a page's raw source bytes for its leading config comment before `text/template.Parse` ever runs (`extractPageConfig` can't be used here — it only runs after template execution, so it can't gate whether execution happens at all). It did this with a regexp, but it runs once per source file on every `render()` call, putting it on the hot path for large sites.

This replaces `pageConfigCommentRe`/its use with `leadingConfigComment`, a hand-written scanner that walks the raw bytes directly: skip whitespace, try an optional case-insensitive `<!DOCTYPE ...>`, skip whitespace again, require the comment to open immediately, then scan for its first close. No behavior change — it reproduces the regex's matching semantics exactly.

### 2. Keep yaml and text/template off pages that don't need them

The FSM turned out not to be the bottleneck. Profiling `BenchmarkPageOptsOutOfTemplating` showed 99.4% of its allocations come from `gopkg.in/yaml.v2` itself: `yaml_parser_initialize` allocates ~2KB of parser scratch buffers on every single `Unmarshal` call, regardless of how small the input is — and the old code called it *unconditionally* whenever a leading comment existed, even on pages that go on to be templated normally and never needed the opt-out check to matter.

```go
func mayDefineTemplateKey(content []byte) bool {
	if hasPrefix(content, bomUTF16LE) || hasPrefix(content, bomUTF16BE) {
		return true
	}
	return bytes.Contains(content, templateKey) ||
		bytes.IndexByte(content, '\\') >= 0 ||
		bytes.IndexByte(content, '!') >= 0
}
```

`mayDefineTemplateKey` scans a comment's bytes and decides whether it could possibly define a `template` key before paying for yaml at all. Getting this exact (never saying no when yaml would say yes) took four guards, not the two that seemed obvious at first:

- the literal bytes `template`, and a backslash — a double-quoted YAML scalar can spell the key without those bytes, e.g. `"\x74emplate": false`
- a stray `!` — yaml.v2's `!!binary` tag base64-decodes into a Go string, so `<!-- !!binary dGVtcGxhdGU=: false -->` (`dGVtcGxhdGU=` is base64 of `template`) opts a page out today with the key never spelled in ASCII
- a leading UTF-16 BOM — yaml.v2 sniffs `\xff\xfe`/`\xfe\xff` at the very start of a stream and transcodes the whole thing, so a comment opening with that BOM can spell `template: false` in UTF-16 with no literal ASCII match either

Every guard is pinned by a regression test proven load-bearing by removing it and confirming the matching test fails (mutation testing, done by hand for each of the four).

The same shape shows up one level out: `render` built a whole single-use `text/template` for every page, including a full copy of the source via `string(input)`, even when the page has no `{{` anywhere and `Parse` would just produce one text node. `render` now writes such pages straight through, verified against `text/template/parse/lex.go`'s `lexText` rather than assumed:

```go
if !bytes.Contains(input, templateActionOpen) || pageOptsOutOfTemplating(input) {
    _, _ = processed.Write(input)
} else {
    // ... existing Parse/Execute path
}
```

The order here is load-bearing, not stylistic. When a page has no `{{`, both branches produce byte-identical output no matter what the config comment says, so `pageOptsOutOfTemplating`'s answer can't change the outcome — and putting `bytes.Contains` first means `||` short-circuits it away entirely. That matters because `mayDefineTemplateKey`'s guards are deliberately one-sided: an innocuous `!` or backslash anywhere in the comment (`Hi!`, a Windows path in a title) still falls through to a real `yaml.Unmarshal`. A plain page never pays for that parse over a question whose answer was never going to matter.

## Benchmark results

All numbers below are from interleaved old/new runs (alternating single-iteration runs between the two binaries rather than running each to completion back-to-back) — an initial non-interleaved pass showed a misleading regression on large-page renders that turned out to be thermal drift on the benchmark machine, caught by re-running the "old" binary afterward and finding it had drifted too.

### Commit 1 — regexp → FSM, `benchstat` (10 runs each) against the old regex-based implementation

```
                                               │    old.txt    │               new.txt               │
                                               │    sec/op     │   sec/op     vs base                │
PageOptsOutOfTemplating/small_with_comment-16      5.298µ ± 1%   4.546µ ± 1%  -14.20% (p=0.000 n=10)
PageOptsOutOfTemplating/large_body_no_match-16     5.999µ ± 1%   4.615µ ± 1%  -23.06% (p=0.000 n=10)
PageOptsOutOfTemplating/no_comment_at_all-16     158.350n ± 6%   6.545n ± 6%  -95.87% (p=0.000 n=10)
geomean                                            1.714µ        515.9n       -69.89%
```

### Commit 2 — yaml/template short-circuits, `benchstat` (interleaved, n=8) against commit 1

```
                                                              │    sec/op     │   sec/op     vs base                │
PageOptsOutOfTemplating/no_comment-16                             6.753n ± 1%   6.467n ± 1%   -4.23% (p=0.000 n=8)
PageOptsOutOfTemplating/comment_without_template_key-16        5129.50n ± 2%   31.02n ± 2%  -99.40% (p=0.000 n=8)
PageOptsOutOfTemplating/comment_with_template_key-16              5.246µ ± 3%   5.333µ ± 1%   +1.66% (p=0.041 n=8)
PageOptsOutOfTemplating/comment_with_backslash-16                 5.214µ ± 1%   5.308µ ± 2%   +1.80% (p=0.015 n=8)
PageOptsOutOfTemplating/large_body_without_template_key-16     5166.00n ± 2%   36.54n ± 2%  -99.29% (p=0.000 n=8)
geomean                                                            1.374µ        183.4n       -86.65%
```

`comment_without_template_key` and `large_body_without_template_key` — an ordinary `<!-- title: ... -->` comment, the shape essentially every real page has — drop from ~5.1µs/40 allocs to ~30-40ns/0 allocs. The two small regressions (`comment_with_template_key`, `comment_with_backslash`) are the guards' documented, deliberate cost: a comment that really does need yaml now pays a few extra byte scans first.

`render` itself was benchmarked with a page mix (small vs. large body, with/without template actions, with/without the `template: false` opt-out), interleaved, n=10-11 after merging two independent interleaved runs:

```
                                 │   sec/op    │  vs base                       │      B/op     vs base       │
Render/plain_page/small-16          79.60µ → 71.37µ   -10.34% (p=0.000 n=11+10) │  -26.71%
Render/plain_page/large-16          4.894m → 4.812m     -1.68% (p=0.043 n=11+10)│   -5.80% (p=0.000)
Render/templated_page/small-16      89.84µ → 81.94µ          ~ (p=0.063 n=10)   │  -17.50% (p=0.000)
Render/templated_page/large-16      4.968m → 4.902m          ~ (p=0.739 n=10)   │   -0.23% (p=0.000)
Render/opted_out_page/small-16      79.00µ → 78.86µ          ~ (p=0.796 n=10)   │        ~
Render/opted_out_page/large-16      4.867m → 4.789m          ~ (p=0.105 n=10)   │        ~
```

`plain_page/small` — a title-only comment, no template actions — is 10% faster with statistical confidence; `plain_page/large` is 1.7% faster in time and 5.8% less memory, small but real at that sample size. The more interesting result is `templated_page/small`: even though it still takes the *same* Parse/Execute code path as before (it does contain `{{`), it allocates 17.5% less, because the old code's unconditional `yaml.Unmarshal` in `pageOptsOutOfTemplating` used to run on every page with *any* leading comment, templated or not — commit 2 removes that wasted parse regardless of which branch `render` ultimately takes. The time delta for that case (p=0.063) doesn't clear significance at this sample size, since the ~4-5µs saved is a smaller fraction of a ~90µs template-execution-dominated call; the allocation numbers make the effect unambiguous. `opted_out_page` and the `/large` cases show no significant time difference either way — HTML5 parsing and the atomic file write dominate wall clock at that size, or the page already paid the real yaml cost for a genuine `template: false`.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .`, `golangci-lint run ./...` all clean
- [x] `go test -race -count=1 ./...` passes, including `TestPageOptsOutOfTemplating` (16 subtests: the original 9 plus 7 new cases pinning `mayDefineTemplateKey`'s guards — `!!binary`, a double-quoted escape, a UTF-16LE comment body, case-sensitivity, "template" appearing only in a value, an unrelated `!`, an unrelated backslash)
- [x] Each new guard proven load-bearing by mutation testing: removing it individually and confirming the matching regression test fails
- [x] Manual differential testing against a reference implementation across two rounds: the regexp-based FSM validation (22 edge cases) from commit 1, and a `mayDefineTemplateKey`-vs-always-yaml differential (44 cases: alternate key spellings, anchors/aliases/merge keys, tags, double-quoted synthesis, near-misses, malformed input) for commit 2 — neither committed, both re-run before finishing
- [x] Byte-identical deploy-output diff between binaries built from the pre- and post-commit-2 code, run against `testdata/site` plus additional fixtures covering every guard (an opted-out page with literal `{{` and trim markers, a `!!binary` opt-out, titles containing `!` and backslashes, a large plain page)
