### PR TITLE
fix(generate): stop shadowing html/template's builtin eq helper

### DIFF
--- a/eq_helper_test.go
+++ b/eq_helper_test.go
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2013 Dario Castañé.
+ * This file is part of Zas.
+ *
+ * Zas is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Zas is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Zas.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package zas
+
+import (
+	"bytes"
+	thtml "html/template"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/melvinmt/gt"
+)
+
+// helpers used to register its own "eq", shadowing html/template's builtin
+// (present since Go 1.6) with a plain a == b comparison: no numeric-kind
+// unification (e.g. int(5) vs int64(5) never matched, even though both are
+// integers of the same value) and a raw panic - recovered by the template
+// engine into an execution error - on uncomparable dynamic types like
+// slices or maps. Removing the registration lets the builtin apply in the
+// layout, the only place "helpers" is ever used (pages render via plain
+// text/template with no Funcs call, so they already got the builtin
+// regardless).
+
+func TestLayoutEqUsesBuiltinNumericUnification(t *testing.T) {
+	// A template integer literal like 5 evaluates as a plain Go int when
+	// passed to an interface{} parameter - confirmed directly, not
+	// assumed - so an explicitly int64-typed value is used here to force a
+	// genuine cross-type comparison within the same numeric kind. A bare
+	// a == b comparison never matches two different concrete Go types
+	// (interface{}(int64(5)) != interface{}(int(5))), but the builtin eq's
+	// int-kind unification does.
+	tmpl := thtml.Must(thtml.New("t").Funcs(helpers).Parse(
+		`{{if eq . 5}}match{{else}}nomatch{{end}}`))
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, int64(5)); err != nil {
+		t.Fatalf("Execute() error = %v, want nil", err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, "match") || strings.Contains(got, "nomatch") {
+		t.Fatalf("output = %q, want \"match\" (builtin eq unifies int64(5) and a template literal 5), not \"nomatch\"", got)
+	}
+}
+
+func TestLayoutEqOnUncomparableTypesReturnsCleanError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.MkdirAll("deploy", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gen := &Generator{
+		Config: ConfigSection{"zas": ConfigSection{"deploy": "deploy"}},
+		I18n:   &gt.Build{Index: gt.Strings{}, Origin: "en"},
+	}
+	// eq on two slices is still an error either way (Execute aborts on
+	// error same as on a recovered panic), but the builtin rejects
+	// uncomparable types with its own error instead of attempting a raw ==
+	// and panicking - so the message should read as a normal template
+	// error, not a recovered Go runtime panic. Two YAML flow-sequence
+	// page-config values (decoded as []interface{}, uncomparable via ==)
+	// reproduce this exactly as the finding itself does.
+	layout, err := thtml.New("layout").Funcs(helpers).Parse(
+		`{{if eq (index .Page "list") (index .Page "list2")}}match{{end}}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gen.Layout = layout
+
+	src := "<!--\nlist: [1, 2]\nlist2: [1, 2]\n-->\n<body>content</body>"
+	err = gen.render("page.html", []byte(src))
+	if err == nil {
+		t.Fatal("render() error = nil, want a non-nil error comparing two uncomparable slices")
+	}
+	if strings.Contains(err.Error(), "runtime error") {
+		t.Fatalf("render() error = %q, want the builtin's own uncomparable-type error, not a recovered Go runtime panic", err.Error())
+	}
+}

--- a/generate.go
+++ b/generate.go
@@ -51,7 +51,6 @@ import (
 
 var helpers = thtml.FuncMap{
 	"noescape": noescape,
-	"eq":       eq,
 }
 
 // rawHTMLRenderer overrides only goldmark's raw-HTML node kinds (block and
@@ -1294,8 +1293,4 @@ func (gen *Generator) resolveMIMETypePlugin(typ string) string {
 
 func noescape(data string) thtml.HTML {
 	return thtml.HTML(data)
-}
-
-func eq(a, b interface{}) bool {
-	return a == b
 }


### PR DESCRIPTION
## Summary

- `helpers` (the `FuncMap` used only for the layout template) registered its own `eq`: a bare `a == b` comparison. This shadowed `html/template`'s builtin `eq` (present since Go 1.6), which is strictly more capable: it unifies numeric kinds (e.g. `int` and `int64` of the same value compare equal — the naive `==` never matches them, since they're different concrete Go types even when numerically identical), and it returns a proper error for uncomparable dynamic types like slices or maps, instead of attempting `==` and relying on the template engine to recover the resulting panic into an execution error.
- Pages already got the builtin regardless of this, since they render via plain `text/template` with no `.Funcs()` call — only the layout was affected. Removing the registration (and the now-dead `eq` function) closes that asymmetry.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./...` (full suite green)
- [x] New tests in `eq_helper_test.go`: `TestLayoutEqUsesBuiltinNumericUnification` (confirmed a genuine before/after difference by first verifying, via a standalone check, that a template integer literal evaluates as plain `int` — so an explicitly `int64`-typed value is used to force a real cross-type comparison within the same numeric kind) and `TestLayoutEqOnUncomparableTypesReturnsCleanError` (two YAML flow-sequence page-config values, reproducing the finding's own case). Both fail against the pre-fix code and pass with the fix.
- [x] Live repro: built the `zas` binary, generated a fixture site with `{{if eq (index .Page "count") 5}}` in the layout against a page config comment `count: 5` — rendered `FIVE` as expected.