### PR TITLE
fix(generate): give a page's own body a working view of Title/Page/FirstTitle

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,14 +160,15 @@ All .md files will be converted to HTML and copied in `.zas/deploy` using `.zas/
 
 Fenced and indented code blocks are rendered as `<pre><code>`, with a fence's info string (e.g. ` ```go `) becoming a `class="language-go"` on the `<code>` element. There is no syntax highlighting built in; style or highlight that class yourself if you want one.
 
-Keep in mind that any file will be treated as a Go text template before any further processing, **including the contents of code blocks**: `{{...}}` inside a fenced or indented block is executed as a template, not shown literally. To display literal double braces, write `{{"{{"}}`. You have access to these fields and methods from anywhere:
+Keep in mind that any file will be treated as a Go text template before any further processing, **including the contents of code blocks**: `{{...}}` inside a fenced or indented block is executed as a template, not shown literally. To display literal double braces, write `{{"{{"}}`. You have access to these fields and methods from anywhere - a page's own content and `layout.html` alike - though `{{.Body}}`, `{{.Title}}`, `{{.Page}}`, and `{{.FirstTitle}}` behave slightly differently depending on which one you use them from; see each below.
 
-* `{{.Body}}`: the file itself in HTML.
-* `{{.Title}}`: autodetected title (first H1 header in file), overridden by `title` property in page's config.
+* `{{.Body}}`: the file's own rendered content in HTML. This is only ever set once the page's own template has finished executing, so it's `layout.html` that receives it - used from inside a page's own content, `{{.Body}}` always evaluates empty, since a page can't contain a preview of its own not-yet-finished render.
+* `{{.Title}}`: autodetected title (first H1 header in file, see `{{.FirstTitle}}` below), overridden by `title` property in page's config (see `{{.Page}}` below). Used from inside a page's own content, this reads a best-effort preview of the same value, extracted from the page's own raw source ahead of its own templating; that preview is occasionally unavailable (falling back to empty, never to unexecuted `{{...}}` syntax) in edge cases `layout.html` doesn't have to worry about, since `layout.html` always sees the final, authoritative value instead.
 * `{{.Path}}`: file's path (also valid as URL).
 * `{{.Site.BaseURL}}`: URL where this site will be deployed, e.g. http://example.com (without final slash).
 * `{{.Site.Image}}`: URL to main image. Useful for Open Graph and Twitter meta tags.
-* `{{.Page}}`: YAML map from first HTML comment (in Markdown and HTML files). It is optional.
+* `{{.Page}}`: YAML map from first HTML comment (in Markdown and HTML files). It is optional. Used from inside a page's own content, this is likewise a best-effort preview parsed from that same leading comment ahead of the page's own templating; `layout.html` always sees the authoritative value, parsed later from the fully rendered page.
+* `{{.FirstTitle}}`: the file's first H1 header text, before any `title` override is applied - what `{{.Title}}` falls back to. Same best-effort preview behavior as `{{.Page}}` when used from inside a page's own content, with one more guard: if the H1 itself is written as `<h1>{{.Title}}</h1>`, the preview is deliberately left unavailable there instead of echoing the literal, unexecuted `{{.Title}}` text back into itself.
 * `{{.Directory}}`: YAML map from above (up to project's directory) or current directory's `.zas.yml` file. It is optional.
 * `{{.URL}}`: full URL for this file.
 * `{{.Extra /path/}}`: direct access to map holding `.zas/config.yml` as it is. You can access to any value with its full path. E.g. BaseURL is also available as `/site/baseurl`.

--- a/data.go
+++ b/data.go
@@ -31,10 +31,34 @@ import (
 // ZasData is the context data store used in templates.
 type ZasData struct {
 	// Template used as body from current file.
+	//
+	// Body is only ever populated after this page's own template has
+	// finished executing - render derives it from that very execution's
+	// HTML5-parsed output (see render in generate.go) - so {{.Body}}
+	// always evaluates empty when used from inside the page's own body
+	// content, unlike in the layout template, which only runs later, once
+	// Body is already populated (see Generate in generate.go). This is an
+	// inherent limitation, not a bug: giving a page's own body a preview
+	// of its own final rendered self would need a multi-pass rendering
+	// model. Contrast with Page and FirstTitle below, which render does
+	// give the page's own body a best-effort preview of, extracted from
+	// the page's raw source ahead of its own template execution (see
+	// earlyPageConfig and leadingH1Text in generate.go) precisely because
+	// neither is circularly defined in terms of that same execution.
 	Body thtml.HTML
 	// Current path (usable in URLs).
 	Path string
 	// Title from first level header (H1).
+	//
+	// Inside the page's own body content (as opposed to the layout),
+	// FirstTitle holds a best-effort preview extracted from the page's raw
+	// source before its own template executes - see leadingH1Text in
+	// generate.go - rather than the canonical value render later derives
+	// from the fully rendered, HTML5-parsed document. The two normally
+	// agree; the preview is left unset only when no leading <h1> is found,
+	// or when one is found but its content still contains unexecuted
+	// template syntax ("{{"), to avoid exposing placeholder text as if it
+	// were a real title.
 	FirstTitle string
 	// Site configuration, as found in ZAS_CONF_FILE.
 	Site ZasSiteData

--- a/generate.go
+++ b/generate.go
@@ -894,6 +894,86 @@ func pageOptsOutOfTemplating(input []byte) bool {
 	return ok && !runTemplate
 }
 
+// earlyPageConfig extracts a best-effort preview of a page's own Page
+// config map straight from input's raw source bytes, before text/template
+// ever runs - the same raw, pre-execution approach leadingConfigComment
+// (and pageOptsOutOfTemplating, built on it) already take for the
+// "template: false" opt-out. It exists so a page's own body can read
+// {{.Page}} (and, through Title's fallback, {{.Title}}) as something other
+// than always empty: render otherwise only populates data.Page from
+// extractPageConfig, which runs on the fully rendered, HTML5-parsed
+// document - strictly after the page's own template has already executed
+// - so the exact same expression that works in the layout used to fail
+// silently inside the page's own body.
+//
+// This is deliberately only a preview. render's later, unconditional call
+// to extractPageConfig - itself untouched by this function - always
+// overwrites data.Page once the document is fully HTML5-parsed, so the
+// layout's own view of data.Page is completely unaffected by whatever this
+// returns. The two extractions are separate implementations of "find the
+// leading config comment" and can in principle disagree on some edge case
+// neither was built to handle identically; that is an acceptable rough
+// edge for a page's own internal, best-effort view, but would not be for
+// the canonical one extractPageConfig produces.
+//
+// A malformed or absent leading comment yields a nil map, matching
+// data.Page's own zero value and today's pre-fix empty behavior, rather
+// than surfacing a duplicate diagnostic: extractPageConfig already reports
+// a malformed comment once the page reaches it later in render.
+func earlyPageConfig(input []byte) map[interface{}]interface{} {
+	content, ok := leadingConfigComment(input)
+	if !ok {
+		return nil
+	}
+	var config map[interface{}]interface{}
+	if err := yaml.Unmarshal(content, &config); err != nil {
+		return nil
+	}
+	return config
+}
+
+// leadingH1Re matches the first <h1>...</h1> element in a document,
+// capturing its inner content. Used only by leadingH1Text.
+var leadingH1Re = regexp.MustCompile(`(?is)<h1[^>]*>(.*?)</h1>`)
+
+// leadingH1Text extracts the first <h1>...</h1> element's inner content
+// from input's raw source bytes, before text/template or HTML5 parsing
+// ever run - the same raw, pre-execution spirit as earlyPageConfig above.
+// It exists only to give a page's own body a best-effort preview of
+// {{.FirstTitle}} (and, through Title's fallback, {{.Title}}); render's
+// later, unconditional getTitle(doc) call - run on the fully HTML5-parsed
+// document, unchanged by this function - always overwrites data.FirstTitle
+// with the canonical value afterward, so the layout's own view is
+// completely unaffected by whatever preview this returns.
+//
+// Unlike getTitle, which walks a parsed tree and so sees plain text, any
+// inner HTML tags here are left exactly as written rather than stripped:
+// stripping them correctly needs the very HTML5 parse this function exists
+// to run ahead of. A raw preview that still contains markup (e.g. an <em>
+// inside the heading) is an acceptable rough edge for an early,
+// best-effort value that gets fully replaced moments later.
+//
+// It refuses to return content containing "{{": a heading written as
+// <h1>{{.Title}}</h1> - a natural pattern for showing the resolved title
+// in the page's own heading - would otherwise hand back the literal,
+// unexecuted string "{{.Title}}" as FirstTitle, and since Title() falls
+// back to FirstTitle when Page["title"] isn't set, that string would
+// circularly render as its own placeholder instead of either failing
+// loudly or resolving. Leaving FirstTitle unset in that case reproduces
+// today's safe, empty behavior instead of exposing template syntax as if
+// it were real content.
+func leadingH1Text(input []byte) (string, bool) {
+	m := leadingH1Re.FindSubmatch(input)
+	if m == nil {
+		return "", false
+	}
+	content := m[1]
+	if bytes.Contains(content, templateActionOpen) {
+		return "", false
+	}
+	return strings.TrimSpace(string(content)), true
+}
+
 // templateActionOpen is text/template's default left delimiter, and the
 // only one render's template ever uses - nothing in this repo calls
 // ttext.New(...).Delims(...). A page containing no "{{" anywhere therefore
@@ -938,6 +1018,23 @@ func (gen *Generator) render(path string, input []byte) (err error) {
 		var template *ttext.Template
 		if template, err = ttext.New("current").Parse(string(input)); err != nil {
 			return
+		}
+		// data.Page and data.FirstTitle are normally only populated after
+		// this very template executes (see the extractPageConfig/getTitle
+		// calls below), since both are derived from the page's own
+		// rendered, HTML5-parsed output - so a page body referencing
+		// {{.Page}}, {{.Title}}, or {{.FirstTitle}} always saw them empty,
+		// even though the identical expression works fine in the layout
+		// (which only runs once render has already finished, via
+		// Generate). Give the page body a best-effort preview of each,
+		// extracted straight from input's raw bytes before this Execute
+		// call runs. The canonical extractPageConfig/getTitle calls below
+		// still run unconditionally afterward and overwrite both with the
+		// real value, so the layout's own view is completely unaffected by
+		// whatever preview the page body saw.
+		data.Page = earlyPageConfig(input)
+		if title, ok := leadingH1Text(input); ok {
+			data.FirstTitle = title
 		}
 		// Pass a pointer: text/template only sees pointer-receiver methods
 		// (Title, E, URL, ...) on an addressable value, and a plain "data" here

--- a/page_data_test.go
+++ b/page_data_test.go
@@ -116,3 +116,126 @@ func testExtractPageConfigTitleOverride(t *testing.T, source string) {
 		t.Fatalf("deployed output = %q, want it to not fall back to the <h1> title %q", got, "Ignored")
 	}
 }
+
+// render used to populate data.Page and data.FirstTitle only after
+// executing the page's own template - both are derived from that very
+// execution's HTML5-parsed output (see extractPageConfig/getTitle in
+// generate.go) - so {{.Title}}, {{.Page}}, and {{.FirstTitle}} always
+// evaluated empty when used from inside a page's own body content, even
+// though the identical expression works fine in the layout. These tests
+// cover the best-effort early preview (earlyPageConfig/leadingH1Text in
+// generate.go, unit-tested directly in raw_page_test.go) that now gives
+// the page body a working view of each, the guard against a
+// self-referential <h1>{{.Title}}</h1> heading, and confirm the layout's
+// own canonical view stays exactly as before regardless of what the page
+// body saw.
+
+func TestRenderPageBodyCanReadTitleFromOwnConfigComment(t *testing.T) {
+	gen := newRenderTestGenerator(t)
+	src := "<!-- title: Custom Title -->\n<p>{{.Title}}</p>"
+
+	if err := gen.render("page.html", []byte(src)); err != nil {
+		t.Fatalf("render() error = %v, want nil", err)
+	}
+	out := readRenderedFile(t, "page.html")
+	if !strings.Contains(out, "<p>Custom Title</p>") {
+		t.Fatalf("deploy output = %q, want the page body's own {{.Title}} to resolve to %q instead of empty", out, "Custom Title")
+	}
+}
+
+func TestRenderPageBodyCanIndexPageMapDirectly(t *testing.T) {
+	gen := newRenderTestGenerator(t)
+	src := "<!-- greeting: hello -->\n" + `<p>{{index .Page "greeting"}}</p>`
+
+	if err := gen.render("page.html", []byte(src)); err != nil {
+		t.Fatalf("render() error = %v, want nil", err)
+	}
+	out := readRenderedFile(t, "page.html")
+	if !strings.Contains(out, "<p>hello</p>") {
+		t.Fatalf(`deploy output = %q, want the page body's own {{index .Page "greeting"}} to resolve to %q instead of empty`, out, "hello")
+	}
+}
+
+func TestRenderPageBodyCanReadFirstTitle(t *testing.T) {
+	gen := newRenderTestGenerator(t)
+	src := "<h1>Heading Text</h1>\n<p>{{.FirstTitle}}</p>"
+
+	if err := gen.render("page.html", []byte(src)); err != nil {
+		t.Fatalf("render() error = %v, want nil", err)
+	}
+	out := readRenderedFile(t, "page.html")
+	if !strings.Contains(out, "<h1>Heading Text</h1>") {
+		t.Fatalf("deploy output = %q, want the literal heading preserved", out)
+	}
+	if !strings.Contains(out, "<p>Heading Text</p>") {
+		t.Fatalf("deploy output = %q, want the page body's own {{.FirstTitle}} to resolve to %q instead of empty", out, "Heading Text")
+	}
+}
+
+// A heading that shows its own resolved title - <h1>{{.Title}}</h1> - is a
+// natural pattern, but a raw pre-execution scan for the page's own H1 would
+// otherwise capture the literal, unexecuted string "{{.Title}}" and hand it
+// back as FirstTitle; since Title() falls back to FirstTitle, that string
+// would then circularly reappear as the page's own "resolved" title.
+// leadingH1Text guards against this (see TestLeadingH1Text in
+// raw_page_test.go for the guard itself); this test confirms render's own
+// pipeline actually benefits from it end to end.
+func TestRenderFirstTitleGuardsAgainstSelfReferentialHeading(t *testing.T) {
+	gen := newRenderTestGenerator(t)
+	src := "<h1>{{.Title}}</h1>"
+
+	if err := gen.render("page.html", []byte(src)); err != nil {
+		t.Fatalf("render() error = %v, want nil", err)
+	}
+	out := readRenderedFile(t, "page.html")
+	if strings.Contains(out, "{{.Title}}") {
+		t.Fatalf("deploy output = %q, want no literal %q leaking out of the self-referential heading", out, "{{.Title}}")
+	}
+	if !strings.Contains(out, "<h1></h1>") {
+		t.Fatalf("deploy output = %q, want an empty <h1></h1> (no page-config title override, FirstTitle unavailable) rather than a circular value", out)
+	}
+}
+
+// The layout executes later, in Generate, using the canonical
+// data.Title()/data.Page/data.FirstTitle that extractPageConfig and
+// getTitle populate from the fully rendered, HTML5-parsed document - not
+// the page body's own early, best-effort preview (render's later,
+// unconditional extractPageConfig/getTitle calls overwrite both after the
+// page's own template has already executed). This confirms both views
+// agree in the normal case: the layout keeps seeing the exact same,
+// correct value the page body's own {{.Title}} now also resolves to,
+// i.e. the fix is additive and doesn't change the layout's own output.
+func TestRenderLayoutTitleUnaffectedByPageBodyPreview(t *testing.T) {
+	gen := newRenderTestGeneratorWithTitleLayout(t)
+	src := "<!-- title: Shared -->\n<p>{{.Title}}</p>"
+
+	if err := gen.render("page.html", []byte(src)); err != nil {
+		t.Fatalf("render() error = %v, want nil", err)
+	}
+	out := readRenderedFile(t, "page.html")
+	if !strings.Contains(out, "<title>Shared</title>") {
+		t.Fatalf("deploy output = %q, want the layout's own {{.Title}} to still resolve to %q", out, "Shared")
+	}
+	if !strings.Contains(out, "<p>Shared</p>") {
+		t.Fatalf("deploy output = %q, want the page body's own {{.Title}} to also resolve to %q", out, "Shared")
+	}
+}
+
+// Body is, by definition, this very execution's own output - there is no
+// way to preview a page's final rendered self ahead of rendering it, unlike
+// Page and FirstTitle above (see the doc comment on ZasData.Body in
+// data.go). {{.Body}} inside a page's own body content is expected to keep
+// evaluating empty; this pins that intentional, documented limitation
+// rather than a fix.
+func TestRenderBodyStaysEmptyInsideOwnPageBody(t *testing.T) {
+	gen := newRenderTestGenerator(t)
+	src := "<p>before</p><span>{{.Body}}</span><p>after</p>"
+
+	if err := gen.render("page.html", []byte(src)); err != nil {
+		t.Fatalf("render() error = %v, want nil", err)
+	}
+	out := readRenderedFile(t, "page.html")
+	if !strings.Contains(out, "<span></span>") {
+		t.Fatalf("deploy output = %q, want {{.Body}} inside the page's own body to evaluate empty (<span></span>)", out)
+	}
+}

--- a/raw_page_test.go
+++ b/raw_page_test.go
@@ -22,6 +22,7 @@ import (
 	thtml "html/template"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -277,5 +278,124 @@ func TestGenerateRawPageSkipsTemplating(t *testing.T) {
 	index := readDeploy(t, "index.html")
 	if !strings.Contains(index, "<title>Home</title>") {
 		t.Fatalf("index.html = %q, want %q (unrelated page still templated normally)", index, "<title>Home</title>")
+	}
+}
+
+// earlyPageConfig and leadingH1Text are the raw, pre-execution
+// counterparts render uses to give a page's own body a best-effort preview
+// of {{.Page}}/{{.Title}} and {{.FirstTitle}}, mirroring
+// leadingConfigComment's approach for the "template: false" opt-out above.
+// Both are covered directly here, then through render() and the H1
+// circularity guard in page_data_test.go.
+
+func TestEarlyPageConfig(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  map[interface{}]interface{}
+	}{
+		{
+			name:  "no comment at all",
+			input: "<h1>Hi</h1>",
+			want:  nil,
+		},
+		{
+			name:  "simple title key",
+			input: "<!-- title: Hi -->\n<h1>Hi</h1>",
+			want:  map[interface{}]interface{}{"title": "Hi"},
+		},
+		{
+			name:  "multiple keys",
+			input: "<!--\ntitle: Hi\nlanguage: en\n-->\n<h1>Hi</h1>",
+			want:  map[interface{}]interface{}{"title": "Hi", "language": "en"},
+		},
+		{
+			name:  "found past a leading doctype",
+			input: "<!DOCTYPE html>\n<!-- title: Hi -->\n<h1>Hi</h1>",
+			want:  map[interface{}]interface{}{"title": "Hi"},
+		},
+		{
+			name:  "malformed YAML comment yields nil, not an error",
+			input: "<!-- language: ru\n\tbad: true\n-->\n<h1>Hi</h1>",
+			want:  nil,
+		},
+		{
+			name:  "comment later in the document doesn't count",
+			input: "<h1>Hi</h1>\n<!-- title: Hi -->",
+			want:  nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := earlyPageConfig([]byte(tt.input))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("earlyPageConfig(%q) = %#v, want %#v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLeadingH1Text(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantText  string
+		wantFound bool
+	}{
+		{
+			name:      "no h1 at all",
+			input:     "<p>Hi</p>",
+			wantFound: false,
+		},
+		{
+			name:      "simple h1",
+			input:     "<h1>Hello</h1>",
+			wantText:  "Hello",
+			wantFound: true,
+		},
+		{
+			name:      "h1 with attributes",
+			input:     `<h1 class="title" id="top">Hello</h1>`,
+			wantText:  "Hello",
+			wantFound: true,
+		},
+		{
+			name:      "only the first h1 counts",
+			input:     "<h1>First</h1><h1>Second</h1>",
+			wantText:  "First",
+			wantFound: true,
+		},
+		{
+			name:      "surrounding whitespace is trimmed",
+			input:     "<h1>\n  Hello  \n</h1>",
+			wantText:  "Hello",
+			wantFound: true,
+		},
+		{
+			name:      "self-referential title is refused",
+			input:     "<h1>{{.Title}}</h1>",
+			wantFound: false,
+		},
+		{
+			name:      "self-referential FirstTitle is refused",
+			input:     "<h1>{{.FirstTitle}}</h1>",
+			wantFound: false,
+		},
+		{
+			name:      "a template action alongside real text is still refused",
+			input:     "<h1>Welcome, {{.Path}}</h1>",
+			wantFound: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := leadingH1Text([]byte(tt.input))
+			if ok != tt.wantFound {
+				t.Fatalf("leadingH1Text(%q) ok = %v, want %v", tt.input, ok, tt.wantFound)
+			}
+			if ok && got != tt.wantText {
+				t.Errorf("leadingH1Text(%q) = %q, want %q", tt.input, got, tt.wantText)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- `{{.Title}}`, `{{.Page}}`, and `{{.FirstTitle}}` always evaluated empty when used from inside a page's own body content, even though the identical expression works fine in the layout template. `render` only populated `data.Page`/`data.FirstTitle` after executing the page's own template, since both are derived from that very execution's HTML5-parsed output.
- The page body now gets a best-effort preview of `Page` and `FirstTitle`, extracted straight from the page's raw source before its own template executes - the same raw, pre-execution approach already used to detect a page's `template: false` opt-out (`leadingConfigComment`/`pageOptsOutOfTemplating`). The canonical `extractPageConfig`/`getTitle` calls further down in `render` still run unconditionally afterward and overwrite both, so the layout's own view is completely unaffected.
- A heading written as `<h1>{{.Title}}</h1>` is guarded against: a raw scan would otherwise capture the literal, unexecuted `"{{.Title}}"` text and hand it back as `FirstTitle` (which `Title()` falls back to), producing circular garbage. The guard leaves `FirstTitle` unavailable there instead.
- `{{.Body}}` is left alone and **not** fixed: it is by definition the very execution's own output, so there's no way to preview a page's final rendered self ahead of rendering it without a multi-pass rendering model. That's now documented as an inherent limitation on `ZasData.Body`.
- README updated to describe the resulting, more nuanced per-context behavior for all four fields.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` all clean
- [x] `golangci-lint run ./...` reports 0 issues
- [x] `go test -race -count=1 ./...` passes
- [x] New unit tests for `earlyPageConfig`/`leadingH1Text` (`raw_page_test.go`), including the H1 self-reference guard
- [x] New `render()`-level tests (`page_data_test.go`) proving a page body using `{{.Title}}`, `{{index .Page "..."}}`, and `{{.FirstTitle}}` now resolves correctly instead of empty, that the circularity guard prevents `<h1>{{.Title}}</h1>` garbage, that the layout's own view is unaffected, and that `{{.Body}}` intentionally stays empty inside a page's own body
- [x] Confirmed the new tests actually fail without the fix (temporarily disabled the two new lines in `render()` and re-ran them)
- [x] Live repro: built the `zas` binary and generated a fixture site with pages using `{{.Title}}`/`{{index .Page "title"}}`/`{{.FirstTitle}}` inside their own body - all resolve correctly, the self-referential `<h1>{{.Title}}</h1>` case renders as empty (`<h1></h1>`) with no leaked template syntax, and the layout's own title rendering is unaffected in every case