### PR TITLE
fix(generate): preserve source file mode when copying assets

### DIFF
--- a/copy_mode_test.go
+++ b/copy_mode_test.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2013 Dario Castañé.
+ * This file is part of Zas.
+ *
+ * Zas is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Zas is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Zas.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package zas
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// copy used to open its destination through atomicWriteFile, which always
+// applies the fixed ZAS_DEFAULT_FILE_PERM (0644) regardless of the
+// source's own mode - so an executable asset (a script, a binary) lost its
+// +x bit on every deploy.
+
+func TestCopyPreservesExecutableBit(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "script.sh")
+	if err := os.WriteFile(src, []byte("#!/bin/sh\necho hi\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(tmp, "deploy", "script.sh")
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	gen := &Generator{}
+	if err := gen.copy(dst, src); err != nil {
+		t.Fatalf("copy() error = %v, want nil", err)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0o755); got != want {
+		t.Fatalf("deployed file mode = %o, want %o (source's own mode preserved)", got, want)
+	}
+}
+
+func TestCopyPreservesNonExecutableMode(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "data.json")
+	if err := os.WriteFile(src, []byte(`{}`), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(tmp, "deploy", "data.json")
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	gen := &Generator{}
+	if err := gen.copy(dst, src); err != nil {
+		t.Fatalf("copy() error = %v, want nil", err)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A regression check for the fix itself, not just the executable case:
+	// the deployed mode should track the source's own mode (0640) rather
+	// than always landing on the fixed ZAS_DEFAULT_FILE_PERM (0644) that
+	// atomicWriteFile applies before copy's chmod runs.
+	if got, want := info.Mode().Perm(), os.FileMode(0o640); got != want {
+		t.Fatalf("deployed file mode = %o, want %o (source's own mode preserved, not the fixed default)", got, want)
+	}
+	if got := os.FileMode(0o644); got == info.Mode().Perm() {
+		t.Fatalf("deployed file mode = %o, want it to differ from the fixed ZAS_DEFAULT_FILE_PERM default, proving the source's own mode was actually applied", got)
+	}
+}

--- a/generate.go
+++ b/generate.go
@@ -1169,7 +1169,15 @@ func (gen *Generator) extractPageConfig(doc *goquery.Document) (config map[inter
 }
 
 /*
- * Copies a file.
+ * Copies a file, preserving the source's permission bits (so an
+ * executable asset stays executable in deploy - atomicWriteFile would
+ * otherwise leave every copy at the fixed ZAS_DEFAULT_FILE_PERM).
+ * Source mtimes are deliberately not preserved: sourceIsNewer's
+ * incremental staleness check treats an equal source/deploy mtime as
+ * stale (its ">=", not ">", is itself a deliberate safe-direction
+ * choice), so copying the source's mtime onto the deploy file would
+ * make every asset look stale, and get recopied, on every incremental
+ * run.
  */
 func (gen *Generator) copy(dstPath, srcPath string) (err error) {
 	src, err := os.Open(srcPath)
@@ -1177,10 +1185,17 @@ func (gen *Generator) copy(dstPath, srcPath string) (err error) {
 		return
 	}
 	defer func() { _ = src.Close() }()
-	return gen.atomicWriteFile(dstPath, func(w io.Writer) error {
+	info, err := src.Stat()
+	if err != nil {
+		return err
+	}
+	if err = gen.atomicWriteFile(dstPath, func(w io.Writer) error {
 		_, err := io.Copy(w, src)
 		return err
-	})
+	}); err != nil {
+		return err
+	}
+	return os.Chmod(dstPath, info.Mode())
 }
 
 // resolveEmbedSrc resolves an <embed src="..."> attribute to an absolute


### PR DESCRIPTION
## Summary

- `copy` wrote its destination through `atomicWriteFile`, which always applies the fixed `ZAS_DEFAULT_FILE_PERM` (0644) regardless of the source's own mode — so an executable asset (a script, a binary) lost its `+x` bit on every deploy, and any other non-default mode was silently normalized to 0644 too.
- `copy` now stats the source before writing and `chmod`s the deployed file to match afterward.
- Source mtimes are deliberately left alone: `sourceIsNewer`'s incremental staleness check treats an equal source/deploy mtime as stale (its `>=`, not `>`, is itself a deliberate safe-direction choice already established elsewhere in this codebase), so copying the source's mtime onto the deploy file would make every asset look stale, and get recopied, on every incremental run. Verified live that this isn't the case with the mode-only fix.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./...` (full suite green)
- [x] New tests in `copy_mode_test.go`: `TestCopyPreservesExecutableBit` (0755 source → 0755 deploy) and `TestCopyPreservesNonExecutableMode` (0640 source → 0640 deploy, explicitly asserting it differs from the fixed 0644 default). Both fail against the pre-fix code and pass with the fix.
- [x] Live repro: built the `zas` binary, generated a fixture site with a 0755 script asset — first (full) run deployed it at 0755; a second incremental run with nothing changed correctly skipped recopying it (no incremental-mode regression); touching the source and running again correctly recopied it, still at 0755.