### PR TITLE
docs: remove stray internal tracking-label prefixes from test comments

### DIFF
--- a/configsection_test.go
+++ b/configsection_test.go
@@ -2,7 +2,7 @@ package zas
 
 import "testing"
 
-// B2: ConfigSection.GetString/GetSection must return zero values instead of
+// ConfigSection.GetString/GetSection must return zero values instead of
 // panicking on a missing or wrongly-typed key.
 
 func TestGetStringMissingKey(t *testing.T) {

--- a/dirconfig_race_test.go
+++ b/dirconfig_race_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-// C1: cachedZasDirectoryConfigs is read and written by every renderAsync
+// cachedZasDirectoryConfigs is read and written by every renderAsync
 // goroutine; run this under `go test -race` to prove there's no longer a
 // concurrent map read/write.
 func TestLoadZasDirectoryConfigConcurrent(t *testing.T) {

--- a/embed_dispatch_test.go
+++ b/embed_dispatch_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/PuerkitoBio/goquery"
 )
 
-// B6: config data must not be able to pick an arbitrary Generator method via
+// config data must not be able to pick an arbitrary Generator method via
 // reflection and panic method.Call with a mismatched arity/signature.
 
 func TestIsEmbedPluginMethod(t *testing.T) {

--- a/i18n_race_test.go
+++ b/i18n_race_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/melvinmt/gt"
 )
 
-// C2: every render used to share one *gt.Build, racing on SetTarget/
+// Every render used to share one *gt.Build, racing on SetTarget/
 // Translate's internal fields and letting one page's language bleed into
 // another's. Run under `go test -race`; also asserts each goroutine only
 // ever observes its own language's translation.

--- a/init_run_test.go
+++ b/init_run_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-// B1: Init.Run must return an error instead of panicking on a write failure.
+// Init.Run must return an error instead of panicking on a write failure.
 
 func TestInitRunWriteFailureReturnsError(t *testing.T) {
 	t.Chdir(t.TempDir())

--- a/newi18n_test.go
+++ b/newi18n_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-// B4: NewI18n must not panic on an entry with no translations, and must
+// NewI18n must not panic on an entry with no translations, and must
 // check the yaml.Unmarshal error before the backfill loop runs.
 
 func TestNewI18nNoFile(t *testing.T) {

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/melvinmt/gt"
 )
 
-// B3: Resolve must error on a present-but-non-string value instead of
+// Resolve must error on a present-but-non-string value instead of
 // panicking on the `.(string)` assertion, while still falling back to ""
 // when the key is genuinely absent.
 

--- a/walk_test.go
+++ b/walk_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-// B5: walk/reaper must return the incoming filepath.Walk error immediately,
+// walk/reaper must return the incoming filepath.Walk error immediately,
 // instead of touching a possibly-nil FileInfo first.
 
 func TestWalkPropagatesErr(t *testing.T) {


### PR DESCRIPTION
## Summary

Eight test-file doc comments (`configsection_test.go`, `dirconfig_race_test.go`, `embed_dispatch_test.go`, `i18n_race_test.go`, `init_run_test.go`, `newi18n_test.go`, `resolve_test.go`, `walk_test.go`) started with a short alphanumeric label (`B1:`, `B2:`, `B3:`, `B4:`, `B5:`, `B6:`, `C1:`, `C2:`) left over from an earlier internal tracking process — meaningless to anyone reading the comment without that external context. This mirrors #47, which cleaned up one earlier instance of the same thing; these eight predate that cleanup.

Pure comment edits: the descriptive sentence after each label is unchanged, no behavior change.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./...` (full suite unchanged and green)
- [x] Swept the repo for any other stray label-shaped comment prefixes — none found beyond these eight.