### PR TITLE
refactor(init): remove dead ZAS_DEFAULT_CONF length guard

### DIFF
--- a/init.go
+++ b/init.go
@@ -120,13 +120,11 @@ func (i *Init) Run() error {
 	} else {
 		fmt.Printf("Reinitialized existing %s repository in %s\n", ZAS_NAME, path)
 	}
-	var data []byte
-	// If default config variable has fields, we store it as ZAS_CONF_FILE (as defined in constants.go).
-	// It overwrites every time we invoke init subcommand.
-	if len(ZAS_DEFAULT_CONF) > 0 {
-		if data, err = yaml.Marshal(&ZAS_DEFAULT_CONF); err != nil {
-			return err
-		}
+	// Stores ZAS_DEFAULT_CONF as ZAS_CONF_FILE (as defined in
+	// constants.go). Overwrites every time we invoke the init subcommand.
+	data, err := yaml.Marshal(&ZAS_DEFAULT_CONF)
+	if err != nil {
+		return err
 	}
 	return os.WriteFile(ZAS_CONF_FILE, data, os.FileMode(ZAS_DEFAULT_FILE_PERM))
 }


### PR DESCRIPTION
## Summary

`Init.Run` guarded its `yaml.Marshal(&ZAS_DEFAULT_CONF)` call with `if len(ZAS_DEFAULT_CONF) > 0`. `ZAS_DEFAULT_CONF` is a literal `ConfigSection` with three top-level keys, never mutated before this check runs in a fresh process, so the guard was always true — and even in the hypothetical empty case, the code would still fall through to `os.WriteFile` with a nil `data` slice, producing an empty config file either way. The guard changed nothing in either branch; it just obscured that this always unconditionally overwrites `.zas/config.yml` (a separate, already-known behavior).

Marshal unconditionally instead.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./...` (full suite green, unchanged — this is a pure refactor with no observable behavior change, so no new test was needed; existing `TestInitRunOK`/`TestInitRunWriteFailureReturnsError` already cover `Init.Run`)
- [x] Live repro: built the `zas` binary, ran `zas init` against a fresh directory, confirmed `.zas/config.yml` is written with the full expected default config (`mimetypes`, `site`, `zas` sections), identical to prior behavior.