### PR TITLE
refactor(generate): take an io.Reader in parseAndReplace

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -258,7 +258,7 @@ func (gen *Generator) Generate(_ string, data *ZasData) (err error) {
 	if err = gen.Layout.Execute(&processed, data); err != nil {
 		return
 	}
-	doc, err := gen.parseAndReplace(processed, data)
+	doc, err := gen.parseAndReplace(&processed, data)
 	if err != nil {
 		return
 	}
@@ -286,14 +286,14 @@ func (gen *Generator) Generate(_ string, data *ZasData) (err error) {
 // goroutine's stack is exhausted.
 const maxEmbedDepth = 20
 
-func (gen *Generator) parseAndReplace(processed bytes.Buffer, data *ZasData) (doc *goquery.Document, err error) {
+func (gen *Generator) parseAndReplace(processed io.Reader, data *ZasData) (doc *goquery.Document, err error) {
 	if data.embedDepth >= maxEmbedDepth {
 		return nil, fmt.Errorf("embed nesting deeper than %d levels; check for a self- or mutually-embedding file", maxEmbedDepth)
 	}
 	data.embedDepth++
 	defer func() { data.embedDepth-- }()
 	// Here we manipulate its result.
-	doc, err = goquery.NewDocumentFromReader(&processed)
+	doc, err = goquery.NewDocumentFromReader(processed)
 	if err != nil {
 		return
 	}
@@ -1043,7 +1043,7 @@ func (gen *Generator) render(path string, input []byte) (err error) {
 			return
 		}
 	}
-	doc, err := gen.parseAndReplace(processed, &data)
+	doc, err := gen.parseAndReplace(&processed, &data)
 	if err != nil {
 		return
 	}
@@ -1239,7 +1239,7 @@ func (gen *Generator) Markdown(e *goquery.Selection, _ *goquery.Document, data *
 		if err := markdownConverter.Convert(mdInput, &b); err != nil {
 			return err
 		}
-		mdDoc, err := gen.parseAndReplace(b, data)
+		mdDoc, err := gen.parseAndReplace(&b, data)
 		if err != nil {
 			return err
 		}
@@ -1287,7 +1287,7 @@ func (gen *Generator) Html(e *goquery.Selection, _ *goquery.Document, data *ZasD
 			return err
 		}
 		var htmlDoc *goquery.Document
-		htmlDoc, err = gen.parseAndReplace(*bytes.NewBuffer(input), data)
+		htmlDoc, err = gen.parseAndReplace(bytes.NewBuffer(input), data)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

- `parseAndReplace(processed bytes.Buffer, …)` copied its `bytes.Buffer` argument by value — the discouraged copy-after-use pattern, safe here only because each copy is read exactly once — and forced an awkward call site in `Html`, which had to dereference `bytes.NewBuffer`'s own `*bytes.Buffer` result (`*bytes.NewBuffer(input)`) just to satisfy the by-value parameter, immediately before the function took its address again internally to call `goquery.NewDocumentFromReader`.
- Switched the parameter to `io.Reader`, the idiomatic shape for a read-once source. All four call sites updated: `Generate`, `render`, and `Markdown` now pass `&processed`/`&b` instead of a value copy; `Html` drops the dereference entirely (`bytes.NewBuffer(input)` instead of `*bytes.NewBuffer(input)`).

Pure refactor, no behavior change.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./...` (full suite unchanged and green — no new test needed, since this only changes the parameter's static type across all four existing call sites, all already covered by e2e/embed tests)
- [x] Live repro: built the `zas` binary, generated a fixture site exercising both the `Markdown` and `Html` embed call sites (the two paths through `parseAndReplace` besides the top-level page/layout ones) — both rendered correctly.