### PR TITLE
fix(generate): route per-file diagnostics to stderr

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -177,13 +177,18 @@ func renderConcurrency() int {
 	return runtime.GOMAXPROCS(0) * 4
 }
 
-// printLine writes args to stdout like fmt.Println, but serialized
+// printLine writes args to stderr like fmt.Println, but serialized
 // against every other printLine call so concurrent renderAsync
-// goroutines (and walk itself) never interleave mid-line.
+// goroutines (and walk itself) never interleave mid-line. Every message
+// printLine carries - progress lines, symlink-skip notices, per-page
+// diagnostics - is either gated behind -verbose or reports a problem, not
+// data the tool produces; stderr keeps stdout free for a future
+// machine-consumable output format and matches the top-level fatal error
+// (cmd/zas/main.go) already going there.
 func (gen *Generator) printLine(args ...interface{}) {
 	gen.printMu.Lock()
 	defer gen.printMu.Unlock()
-	fmt.Println(args...)
+	fmt.Fprintln(os.Stderr, args...)
 }
 
 /*
@@ -547,7 +552,7 @@ func (gen *Generator) reaper(path string, _ os.FileInfo, err error) (ierr error)
 		}
 		if reap {
 			if gen.Verbose {
-				fmt.Println("-", sourcePath)
+				gen.printLine("-", sourcePath)
 			}
 			if rmErr := os.RemoveAll(path); rmErr != nil {
 				gen.recordErr(rmErr)

--- a/render_error_reporting_test.go
+++ b/render_error_reporting_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/melvinmt/gt"
 )
 
-// captureStdout is defined in symlink_test.go and reused here.
+// captureStderr is defined in symlink_test.go and reused here.
 
 // newRenderTestGenerator builds a minimal Generator suitable for calling
 // render() directly, deploying into ./deploy under a fresh chdir'd temp
@@ -64,7 +64,7 @@ func TestRenderParseAndReplaceErrorNotPrintedInline(t *testing.T) {
 	src := `<body><embed src="x" type="text/x-nope"></body>`
 
 	var err error
-	stdout := captureStdout(t, func() {
+	stderr := captureStderr(t, func() {
 		err = gen.render("page.html", []byte(src))
 	})
 
@@ -74,8 +74,8 @@ func TestRenderParseAndReplaceErrorNotPrintedInline(t *testing.T) {
 	if !strings.Contains(err.Error(), "text/x-nope") {
 		t.Fatalf("render() error = %v, want it to mention the embed type", err)
 	}
-	if strings.Contains(stdout, "text/x-nope") {
-		t.Fatalf("render() printed the error directly to stdout (%q); it must be reported exactly once, by its caller", stdout)
+	if strings.Contains(stderr, "text/x-nope") {
+		t.Fatalf("render() printed the error directly (%q); it must be reported exactly once, by its caller", stderr)
 	}
 }
 
@@ -103,15 +103,15 @@ func TestRenderReportsMalformedPageConfigCommentButKeepsGoing(t *testing.T) {
 	src := "<!-- language: ru\n\tbad: true\n-->\n<h1>Hi</h1>"
 
 	var err error
-	stdout := captureStdout(t, func() {
+	stderr := captureStderr(t, func() {
 		err = gen.render("page.html", []byte(src))
 	})
 
 	if err != nil {
 		t.Fatalf("render() error = %v, want nil (a malformed page config comment must not abort the render)", err)
 	}
-	if !strings.Contains(stdout, "page.html") {
-		t.Fatalf("render() stdout = %q, want it to report the malformed page config comment", stdout)
+	if !strings.Contains(stderr, "page.html") {
+		t.Fatalf("render() stderr = %q, want it to report the malformed page config comment", stderr)
 	}
 
 	out, readErr := os.ReadFile(filepath.Join("deploy", "page.html"))

--- a/symlink_test.go
+++ b/symlink_test.go
@@ -19,21 +19,21 @@ import (
 // confirm both kinds are now skipped explicitly, with a message, instead of
 // either mishandling.
 
-// captureStdout redirects os.Stdout for the duration of fn and returns
-// everything written to it.
-func captureStdout(t *testing.T, fn func()) string {
+// captureStderr redirects os.Stderr for the duration of fn and returns
+// everything written to it. printLine (generate.go) writes there.
+func captureStderr(t *testing.T, fn func()) string {
 	t.Helper()
-	orig := os.Stdout
+	orig := os.Stderr
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatal(err)
 	}
-	os.Stdout = w
+	os.Stderr = w
 	fn()
 	if err := w.Close(); err != nil {
 		t.Fatal(err)
 	}
-	os.Stdout = orig
+	os.Stderr = orig
 	out, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatal(err)
@@ -55,7 +55,7 @@ func TestWalkSkipsSymlinkedDirectoryWithMessage(t *testing.T) {
 	}
 	gen := &Generator{}
 	var walkErr error
-	out := captureStdout(t, func() {
+	out := captureStderr(t, func() {
 		walkErr = gen.walk("linkdir", info, nil)
 	})
 	if walkErr != nil {
@@ -84,7 +84,7 @@ func TestWalkSkipsSymlinkedFileWithMessage(t *testing.T) {
 	}
 	gen := &Generator{}
 	var walkErr error
-	out := captureStdout(t, func() {
+	out := captureStderr(t, func() {
 		walkErr = gen.walk("link.txt", info, nil)
 	})
 	if walkErr != nil {


### PR DESCRIPTION
## Summary

- Progress lines (`+ path`), symlink-skip notices, per-page config errors, and the reaper's own removal notices all went to **stdout** via `printLine`, or a bare `fmt.Println` in reaper's case. None of it is data the tool produces — it's either gated behind `-verbose` or reports a problem — so it belongs on stderr, matching the top-level fatal error `cmd/zas/main.go` already routes there.
- `printLine` now writes through `fmt.Fprintln(os.Stderr, ...)` instead of `fmt.Println`; reaper's stray direct `fmt.Println` call is folded into `printLine` too, for one consistent, already-mutex-serialized path.
- `captureStdout` (`symlink_test.go`, also used by `render_error_reporting_test.go`) is renamed `captureStderr` and now redirects `os.Stderr`, since that's where every message it captures actually goes now.

Not addressed (explicitly out of scope, a bigger CLI-design ask than this fix): a `-quiet` flag, structured/machine-parseable log levels beyond the single `-verbose` bool. This fix is scoped to the concrete "wrong stream" bug, not a logging-framework redesign.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./...` (full suite green, with the 4 existing tests that capture `printLine`'s output updated to capture stderr)
- [x] Live repro with explicit stream redirection: built the `zas` binary, ran `generate -verbose` against a fixture with a symlink, a malformed page-config comment, and normal pages, redirecting stdout and stderr to separate files — stdout came back completely empty; stderr had the verbose `+` progress lines, the symlink-skip notice, and the malformed-comment error. A second run against a fixture with a since-deleted source confirmed the reaper's own `-` removal notice lands on stderr too.