### PR TITLE
feat(generate): enable GFM and footnote goldmark extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ drwxr-xr-x  7 Dario  staff  238 30 mar 16:19 ..
 
 All .md files will be converted to HTML and copied in `.zas/deploy` using `.zas/layout.html` as layout and copying any other files and their structure. The former is also true for HTML files.
 
+Markdown is parsed as [GitHub Flavored Markdown](https://github.github.com/gfm/) (tables, strikethrough, task lists, autolinks) plus footnotes, on top of CommonMark. No configuration needed; it's always on.
+
 Fenced and indented code blocks are rendered as `<pre><code>`, with a fence's info string (e.g. ` ```go `) becoming a `class="language-go"` on the `<code>` element. There is no syntax highlighting built in; style or highlight that class yourself if you want one.
 
 Keep in mind that any file will be treated as a Go text template before any further processing, **including the contents of code blocks**: `{{...}}` inside a fenced or indented block is executed as a template, not shown literally. To display literal double braces, write `{{"{{"}}`. You have access to these fields and methods from anywhere - a page's own content and `layout.html` alike - though `{{.Body}}`, `{{.Title}}`, `{{.Page}}`, and `{{.FirstTitle}}` behave slightly differently depending on which one you use them from; see each below.

--- a/generate.go
+++ b/generate.go
@@ -40,6 +40,7 @@ import (
 	"github.com/melvinmt/gt"
 	markdown "github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/renderer"
 	"github.com/yuin/goldmark/util"
 	html5 "golang.org/x/net/html"
@@ -97,9 +98,20 @@ func (r *rawHTMLRenderer) renderRawHTML(w util.BufWriter, source []byte, node as
 // directly in a .md file would otherwise never reach Zas. Built once at
 // package init and shared across renderAsync goroutines: goldmark builds a
 // fresh parse context per Convert call, so this is safe for concurrent use.
-var markdownConverter = markdown.New(markdown.WithRendererOptions(
-	renderer.WithNodeRenderers(util.Prioritized(&rawHTMLRenderer{}, 100)),
-))
+//
+// extension.GFM (tables, strikethrough, task lists, autolinks) and
+// extension.Footnote are enabled on top of goldmark's default CommonMark
+// parsing - previously neither was, so e.g. a GFM table rendered as a
+// literal paragraph of pipe characters instead of a <table>. Both are
+// purely additive: they recognize syntax CommonMark alone leaves as plain
+// text, so existing content that doesn't use any of it renders exactly as
+// before.
+var markdownConverter = markdown.New(
+	markdown.WithExtensions(extension.GFM, extension.Footnote),
+	markdown.WithRendererOptions(
+		renderer.WithNodeRenderers(util.Prioritized(&rawHTMLRenderer{}, 100)),
+	),
+)
 
 // Generator groups relevant rendering info.
 type Generator struct {

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -108,3 +108,55 @@ func TestMarkdownIndentedCodeBlockRenders(t *testing.T) {
 		t.Fatalf("output = %q, want an indented code block wrapped in <pre><code>", out)
 	}
 }
+
+// markdownConverter enables extension.GFM (tables, strikethrough, task
+// lists, autolinks) and extension.Footnote on top of goldmark's default
+// CommonMark parsing. Previously neither was enabled, so this syntax
+// rendered as plain, unprocessed text - most visibly a GFM table showing
+// up as a literal paragraph of pipe characters instead of a <table>.
+
+func TestMarkdownRendersGFMTable(t *testing.T) {
+	out := convertMarkdown(t, "| A | B |\n|---|---|\n| 1 | 2 |\n")
+	for _, want := range []string{"<table>", "<th>A</th>", "<th>B</th>", "<td>1</td>", "<td>2</td>"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output = %q, want it to contain %q", out, want)
+		}
+	}
+	if strings.Contains(out, "| A | B |") {
+		t.Fatalf("output = %q, table syntax was left as literal text", out)
+	}
+}
+
+func TestMarkdownRendersStrikethrough(t *testing.T) {
+	out := convertMarkdown(t, "~~struck~~\n")
+	if !strings.Contains(out, "<del>struck</del>") {
+		t.Fatalf("output = %q, want strikethrough syntax rendered as <del>", out)
+	}
+}
+
+func TestMarkdownRendersTaskList(t *testing.T) {
+	out := convertMarkdown(t, "- [ ] todo\n- [x] done\n")
+	if !strings.Contains(out, `<input disabled="" type="checkbox">`) {
+		t.Fatalf("output = %q, want an unchecked task list checkbox", out)
+	}
+	if !strings.Contains(out, `<input checked="" disabled="" type="checkbox">`) {
+		t.Fatalf("output = %q, want a checked task list checkbox", out)
+	}
+}
+
+func TestMarkdownRendersAutolink(t *testing.T) {
+	out := convertMarkdown(t, "See http://example.com for more.\n")
+	if !strings.Contains(out, `<a href="http://example.com">http://example.com</a>`) {
+		t.Fatalf("output = %q, want the bare URL linkified", out)
+	}
+}
+
+func TestMarkdownRendersFootnote(t *testing.T) {
+	out := convertMarkdown(t, "Body text.[^1]\n\n[^1]: The footnote.\n")
+	if !strings.Contains(out, "The footnote.") {
+		t.Fatalf("output = %q, want the footnote definition rendered", out)
+	}
+	if !strings.Contains(out, `href="#fn:1"`) || !strings.Contains(out, `id="fn:1"`) {
+		t.Fatalf("output = %q, want a footnote reference link and its matching definition anchor", out)
+	}
+}


### PR DESCRIPTION
## Summary

- `markdownConverter` used goldmark's default CommonMark parsing only, carried over from the old blackfriday call's `WithNoExtensions()` option. Anyone coming from a GFM-based static site generator got silently different output for syntax they'd expect to work: a GFM table rendered as a literal paragraph of pipe characters instead of a `<table>`, `~~strikethrough~~` stayed as literal tildes, a bare URL never became a link, and `[^1]`-style footnotes rendered as plain bracketed text.
- Enabled `extension.GFM` (tables, strikethrough, task lists, autolinks) and `extension.Footnote`. Both are purely additive: they recognize syntax CommonMark alone leaves as plain text, so existing content that doesn't use any of it is unaffected.
- README documents the resulting dialect (GFM + footnotes on top of CommonMark) where it already describes how `.md` files are processed.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./...` (full suite green)
- [x] New tests: `TestMarkdownRendersGFMTable`, `TestMarkdownRendersStrikethrough`, `TestMarkdownRendersTaskList`, `TestMarkdownRendersAutolink`, `TestMarkdownRendersFootnote` — all confirmed to fail against the pre-fix code (rendering the syntax as plain, unprocessed text) and pass with the fix.
- [x] Grepped existing `testdata/` fixtures for pipe/tilde/task-list/footnote syntax before enabling this, to rule out an accidental behavior change on existing content — found none.
- [x] Live repro: built the `zas` binary, generated a fixture page combining a table, strikethrough, an autolink, and a task list — all rendered correctly end-to-end through the real `zas generate` pipeline.