### PR TITLE
fix(generate): recognize .md/.html extensions case-insensitively

### DIFF
--- a/extension_test.go
+++ b/extension_test.go
@@ -1,6 +1,10 @@
 package zas
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 // sourceIsNewer, NewZasData, and reaper each used to swap .md/.html
 // extensions with strings.Replace/ReplaceAll on the whole path string,
@@ -22,11 +26,43 @@ func TestSwapExtension(t *testing.T) {
 		{"trailing occurrence swapped even when an earlier one matches to", "x.html.md", ".md", ".html", "x.html.html"},
 		{"reverse swap also only touches the trailing occurrence", "x.html.html", ".html", ".md", "x.html.md"},
 		{"path without the suffix is returned unchanged", "style.css", ".md", ".html", "style.css"},
+		{"uppercase extension matches and is normalized to to's own case", "PAGE.MD", ".md", ".html", "PAGE.html"},
+		{"mixed-case extension matches too", "page.Md", ".md", ".html", "page.html"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			if got := swapExtension(c.path, c.from, c.to); got != c.want {
 				t.Fatalf("swapExtension(%q, %q, %q) = %q, want %q", c.path, c.from, c.to, got, c.want)
+			}
+		})
+	}
+}
+
+// renderAsync's dispatch switch used to match ".md"/".html" with
+// strings.HasSuffix, case-sensitively, so a README.MD or page.Md source
+// fell through to the copy branch and shipped into deploy verbatim,
+// unrendered, keeping its original (unrecognized) extension. Both it and
+// swapExtension now share hasExtension for a single, consistent notion of
+// "does this path have extension X".
+func TestHasExtension(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		ext  string
+		want bool
+	}{
+		{"exact case match", "page.md", ".md", true},
+		{"all-uppercase extension matches", "PAGE.MD", ".md", true},
+		{"mixed-case extension matches", "page.Md", ".md", true},
+		{"non-matching extension", "page.html", ".md", false},
+		{"extension-like mid-name segment doesn't count", "v1.mdx", ".md", false},
+		{"path shorter than the extension", ".m", ".md", false},
+		{"empty path", "", ".md", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := hasExtension(c.path, c.ext); got != c.want {
+				t.Fatalf("hasExtension(%q, %q) = %v, want %v", c.path, c.ext, got, c.want)
 			}
 		})
 	}
@@ -44,5 +80,60 @@ func TestSwapExtensionRoundTrip(t *testing.T) {
 				t.Fatalf("round trip through %q = %q, want %q", html, back, orig)
 			}
 		})
+	}
+}
+
+// A case-varied extension deliberately does not round-trip: swapExtension
+// always produces to's own casing, so PAGE.MD's deploy path is PAGE.html,
+// not PAGE.HTML, and swapping that back yields PAGE.md, not the original
+// PAGE.MD. This gives every consumer (walk, sourceIsNewer, reaper,
+// NewZasData) one single, predictable extension casing to agree on,
+// instead of each needing to separately preserve or normalize whatever
+// casing the source file happened to use.
+func TestSwapExtensionNormalizesCase(t *testing.T) {
+	if got, want := swapExtension("PAGE.MD", ".md", ".html"), "PAGE.html"; got != want {
+		t.Fatalf("swapExtension(%q, ...) = %q, want %q", "PAGE.MD", got, want)
+	}
+}
+
+// reaper reconstructs a candidate source path from a deploy path via
+// swapExtension, which - per TestSwapExtensionNormalizesCase above - always
+// normalizes the guessed extension's own casing. Since a real source's
+// casing might not be that guess (e.g. PAGE.MD's guessed source is
+// "page.md", not "PAGE.MD"), reaper needs a case-insensitive existence
+// check, not a plain os.Open on the exact guessed path.
+func TestGeneratorExistsFold(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "PAGE.MD"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gen := &Generator{}
+	if !gen.existsFold(filepath.Join(dir, "page.md")) {
+		t.Fatalf("existsFold(%q) = false, want true (PAGE.MD exists, compared case-insensitively)", filepath.Join(dir, "page.md"))
+	}
+	if gen.existsFold(filepath.Join(dir, "other.md")) {
+		t.Fatal("existsFold(...) = true for a file that doesn't exist, want false")
+	}
+}
+
+// existsFold caches each directory's entries in dirEntriesFoldCache after
+// its first read, rather than re-reading and re-scanning the same
+// directory listing on every call - otherwise a directory with many files
+// pays for one full directory read per file instead of one total. This
+// pins the caching itself: a file created after the first existsFold call
+// for its directory must not suddenly become visible within the same
+// Generator, since the whole point is that the directory is read only
+// once per reap walk.
+func TestGeneratorExistsFoldCachesDirectoryListing(t *testing.T) {
+	dir := t.TempDir()
+	gen := &Generator{}
+	if gen.existsFold(filepath.Join(dir, "page.md")) {
+		t.Fatal("existsFold(...) = true before the file was ever created")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "page.md"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if gen.existsFold(filepath.Join(dir, "page.md")) {
+		t.Fatal("existsFold(...) = true after the file appeared, want the cached (pre-creation) listing still in effect")
 	}
 }

--- a/generate.go
+++ b/generate.go
@@ -169,6 +169,17 @@ type Generator struct {
 	// current reap walk. The reap walk is single-threaded, so no mutex.
 	reapedDirs map[string]struct{}
 
+	// dirEntriesFoldCache caches, per directory, the lowercased basenames
+	// of its entries - built lazily by existsFold on first use and reused
+	// for every other file existsFold is asked about in the same
+	// directory during the current reap walk. Without it, a directory
+	// with many files (case-insensitive extension matching means reaper
+	// can no longer trust a single exact-path os.Open, see existsFold)
+	// would re-read and re-scan the same directory listing once per file
+	// instead of once total. Like reapedDirs, the reap walk that fills
+	// this is single-threaded, so no mutex.
+	dirEntriesFoldCache map[string]map[string]struct{}
+
 	// claimedOutputs maps each deploy output path claimed so far to the
 	// source path that claimed it, so two sources that render to the same
 	// output (e.g. foo.md and foo.html) don't both spawn a renderAsync
@@ -222,15 +233,53 @@ func (gen *Generator) BuildDeployPath(path string) string {
 	return filepath.Join(gen.GetDeployPath(), path)
 }
 
-// swapExtension replaces path's trailing from extension with to. Paths not
+// hasExtension reports whether path ends in ext, matched case-insensitively
+// so PAGE.MD and page.Md are both recognized the same as page.md - a
+// filesystem that preserves the case a file was created with doesn't mean
+// every file on it was typed in the same case.
+func hasExtension(path, ext string) bool {
+	return len(path) >= len(ext) && strings.EqualFold(path[len(path)-len(ext):], ext)
+}
+
+// swapExtension replaces path's trailing from extension with to, matched
+// case-insensitively via hasExtension (so PAGE.MD swaps just like
+// page.md - always producing to's own casing, never from's). Paths not
 // ending in from are returned unchanged. Unlike strings.Replace/ReplaceAll,
 // this only ever touches the extension, never a from/to occurrence earlier
 // in path.
 func swapExtension(path, from, to string) string {
-	if !strings.HasSuffix(path, from) {
+	if !hasExtension(path, from) {
 		return path
 	}
-	return strings.TrimSuffix(path, from) + to
+	return path[:len(path)-len(from)] + to
+}
+
+// existsFold reports whether a file matching name exists in name's
+// directory, compared case-insensitively against the directory's actual
+// entries. reaper reconstructs a candidate source path from a deploy path
+// via swapExtension, which always normalizes to's own casing - so a guess
+// like "./page.md" needs to still find a real "PAGE.MD" source on a
+// case-sensitive filesystem. Each directory's entries are read at most
+// once per reap walk and cached in dirEntriesFoldCache: a directory with
+// many files would otherwise pay for a full re-read and re-scan of the
+// same listing once per file instead of once total.
+func (gen *Generator) existsFold(name string) bool {
+	dir := filepath.Dir(name)
+	names, ok := gen.dirEntriesFoldCache[dir]
+	if !ok {
+		names = map[string]struct{}{}
+		if entries, err := os.ReadDir(dir); err == nil {
+			for _, e := range entries {
+				names[strings.ToLower(e.Name())] = struct{}{}
+			}
+		}
+		if gen.dirEntriesFoldCache == nil {
+			gen.dirEntriesFoldCache = make(map[string]map[string]struct{})
+		}
+		gen.dirEntriesFoldCache[dir] = names
+	}
+	_, found := names[strings.ToLower(filepath.Base(name))]
+	return found
 }
 
 // atomicWriteFile calls write with a temporary file in path's own directory
@@ -512,9 +561,9 @@ func (gen *Generator) renderAsync(path string) {
 	}
 
 	switch {
-	case strings.HasSuffix(path, ".md"):
+	case hasExtension(path, ".md"):
 		err = gen.renderMarkdown(path)
-	case strings.HasSuffix(path, ".html"):
+	case hasExtension(path, ".html"):
 		err = gen.renderHTML(path)
 	default:
 		err = gen.copy(gen.BuildDeployPath(path), path)
@@ -554,11 +603,18 @@ func (gen *Generator) reaper(path string, _ os.FileInfo, err error) (ierr error)
 	// TODO it must clean directories too
 	if err != nil {
 		reap := true
-		if strings.HasSuffix(sourcePath, ".html") {
+		if hasExtension(sourcePath, ".html") {
+			// swapExtension always normalizes to's own casing, so this
+			// guess (e.g. "./page.md") can only ever be lowercase,
+			// regardless of what case the real source used - a plain
+			// os.Open here would never find a differently-cased source
+			// like "PAGE.MD" on a case-sensitive filesystem. Note this
+			// isn't needed above: an .html-sourced deploy path is never
+			// extension-swapped at all (swapExtension's from is always
+			// ".md"), so it keeps the source's exact original casing, and
+			// plain os.Open above already matches it correctly.
 			sourcePath = swapExtension(sourcePath, ".html", ".md")
-			sourceNew, err := os.Open(sourcePath)
-			if err == nil {
-				_ = sourceNew.Close()
+			if gen.existsFold(sourcePath) {
 				reap = false
 			}
 		}

--- a/generate_e2e_test.go
+++ b/generate_e2e_test.go
@@ -54,6 +54,38 @@ func TestGenerateConvertsMarkdown(t *testing.T) {
 	}
 }
 
+// renderAsync's dispatch switch used to match ".md"/".html" case-
+// sensitively, so an uppercase-extension source like PAGE.MD fell through
+// to the copy branch and shipped into deploy verbatim (unrendered),
+// keeping its original PAGE.MD name instead of being converted and
+// deployed as PAGE.html.
+//
+// generate(t) here exercises the full pipeline in one call, including the
+// reap phase - which matters, because fixing only the dispatch switch
+// uncovered a second bug: reaper reconstructs a candidate source path from
+// a deploy path via swapExtension, which always normalizes the guessed
+// extension's casing, so its guess for PAGE.html's source was "page.md",
+// not "PAGE.MD". A plain os.Open on that lowercase guess never finds the
+// real, differently-cased source, so reaper wrongly treated PAGE.html as
+// stale and deleted it immediately after render() created it. PAGE.html
+// still being present after generate(t) returns is proof reaper's own
+// existence check (existsFold) is now case-insensitive too, not just the
+// render dispatch.
+func TestGenerateRendersUppercaseMarkdownExtension(t *testing.T) {
+	newTestSite(t, "site")
+	if err := os.WriteFile("PAGE.MD", []byte("# Upper\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := generate(t); err != nil {
+		t.Fatalf("generate() error = %v, want nil", err)
+	}
+	assertDeployHas(t, "PAGE.html")
+	assertDeployMissing(t, "PAGE.MD")
+	if out := readDeploy(t, "PAGE.html"); !strings.Contains(out, "<h1>Upper</h1>") {
+		t.Fatalf("PAGE.html = %q, want it converted from Markdown, not copied verbatim", out)
+	}
+}
+
 func TestGenerateResolvesHTMLEmbed(t *testing.T) {
 	newTestSite(t, "site")
 	if err := generate(t); err != nil {


### PR DESCRIPTION
## Summary

- `renderAsync`'s dispatch switch matched `.md`/`.html` with `strings.HasSuffix`, case-sensitively, so an uppercase-extension source like `README.MD` or `page.Md` fell through to the copy branch and shipped into deploy verbatim, unrendered, keeping its original (unrecognized) extension instead of being converted and deployed with the expected `.html` one.
- `swapExtension` and a new `hasExtension` helper it now shares match case-insensitively, and always produce `to`'s own casing rather than preserving `from`'s — so `PAGE.MD`'s deploy path is `PAGE.html`, not `PAGE.HTML`.
- Whether alternate spellings like `.markdown` should also be recognized is a separate, undecided product question — this only fixes case, the same extension the codebase already looks for.

Normalizing the deploy path's casing surfaced a second, deeper bug: `reaper` reconstructs a candidate `.md` source path from a `.html` deploy path via `swapExtension`, and a plain `os.Open` on that always-lowercase guess can no longer find a differently-cased real source on a case-sensitive filesystem — so `reaper` wrongly treated a freshly rendered `PAGE.html` as stale (its guessed source, `page.md`, doesn't exist; the real one is `PAGE.MD`) and deleted it immediately after `render()` created it. `reaper`'s existence check is now case-insensitive too (`existsFold`), with each directory's entries read and cached once per reap walk rather than once per file — an earlier version without that caching regressed `TestGenerateKillMidRunNeverLeavesPartialFinalFile` (a 3000-page fixture) from ~3s to ~40s by re-reading the same directory listing for every page.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./...` (full suite green, and back to its normal ~3-4s runtime after the caching fix — confirmed the pre-caching version's ~40s regression and that this resolves it)
- [x] New tests: `TestHasExtension`, case-insensitive cases added to `TestSwapExtension`, `TestSwapExtensionNormalizesCase`, `TestGeneratorExistsFold`, `TestGeneratorExistsFoldCachesDirectoryListing`, and an e2e test `TestGenerateRendersUppercaseMarkdownExtension` that exercises the full pipeline (render + reap) in one `generate()` call, which is what actually caught the reaper bug.
- [x] Live repro: built the `zas` binary, generated a fixture site with a `PAGE.MD` source — first run rendered it correctly to `PAGE.html`; a second incremental run correctly left it in place (no spurious re-copy or reap).