### PR TITLE
fix: build deploy-config and URL paths without hardcoded separators

### DIFF
--- a/data.go
+++ b/data.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	thtml "html/template"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/melvinmt/gt"
@@ -190,11 +191,17 @@ func (zd *ZasData) IsHome() (bool, error) {
 	return zd.Path == "/index.html" || zd.Path == fmt.Sprintf("/%s/index.html", lang), nil
 }
 
-// NewZasData builds a ZasData for the page at filepath.
-func NewZasData(filepath string, gen *Generator) (data ZasData) {
+// NewZasData builds a ZasData for the page at srcPath.
+func NewZasData(srcPath string, gen *Generator) (data ZasData) {
 	// Any path must finish in ".html".
-	filepath = swapExtension(filepath, ".md", ".html")
-	data.Path = "/" + filepath
+	srcPath = swapExtension(srcPath, ".md", ".html")
+	// filepath.Walk (the only caller) yields srcPath with the OS's own
+	// separator, but data.Path becomes a URL - which always uses forward
+	// slashes regardless of platform, so a nested page on Windows doesn't
+	// end up with a literal backslash in its URL (and, via IsHome's
+	// hardcoded "/"-separated comparisons below, so a language-prefixed
+	// home page can still be recognized as one there too).
+	data.Path = "/" + filepath.ToSlash(srcPath)
 	data.config = gen.Config
 	// Each ZasData gets its own gt.Build sharing the (read-only, post-init)
 	// Index, so per-render SetTarget/Translate calls don't race or bleed

--- a/generate.go
+++ b/generate.go
@@ -727,7 +727,7 @@ func (gen *Generator) loadZasDirectoryConfig(currentpath string) (config ConfigS
 		}
 		return entry.config, entry.modTime, nil
 	}
-	confPath := fmt.Sprintf("%s/%s", path, ZAS_DIR_CONF_FILE)
+	confPath := filepath.Join(path, ZAS_DIR_CONF_FILE)
 	data, err := os.ReadFile(confPath)
 	if err != nil {
 		// Maybe .zas.yml is in an upper directory (already cached or not),

--- a/page_data_test.go
+++ b/page_data_test.go
@@ -34,6 +34,32 @@ func TestZasDataPointerMethodsNeedAddressableValue(t *testing.T) {
 	}
 }
 
+// NewZasData builds data.Path from filepath.Walk's own path argument,
+// which uses the OS's native separator - "/" on Unix, "\" on Windows. Since
+// data.Path becomes a URL, not a filesystem path, it must always use "/"
+// regardless of platform: a nested page's URL containing a literal
+// backslash would be wrong, and IsHome's own hardcoded "/"-separated
+// comparisons further down would never match a language-prefixed home
+// page's path if it had backslashes in it instead.
+//
+// filepath.ToSlash is a documented no-op wherever the OS separator is
+// already "/" - true for every platform this test suite actually runs on
+// - so this only pins that ordinary Unix-style input is unaffected; the
+// backslash-to-slash conversion itself only ever executes on a real
+// Windows build, which isn't something this repo's test suite can
+// exercise directly. GOOS=windows go build/vet at least confirm the
+// change compiles and type-checks for that target.
+func TestNewZasDataBuildsForwardSlashPath(t *testing.T) {
+	gen := &Generator{
+		Config: ConfigSection{},
+		I18n:   &gt.Build{Index: gt.Strings{}, Origin: "en"},
+	}
+	data := NewZasData(filepath.Join("sub", "page.html"), gen)
+	if want := "/sub/page.html"; data.Path != want {
+		t.Fatalf("NewZasData(...).Path = %q, want %q", data.Path, want)
+	}
+}
+
 func TestRenderPageBodyCanCallPointerReceiverMethod(t *testing.T) {
 	t.Chdir(t.TempDir())
 	if err := os.MkdirAll("deploy", 0o755); err != nil {


### PR DESCRIPTION
## Summary

Two remaining Windows-portability gaps, once E4's fix to the `.zas` directory skip check (which already switched to `filepath.Separator`) is set aside as already resolved:

- `loadZasDirectoryConfig` built its `.zas.yml` candidate path with `fmt.Sprintf("%s/%s", path, ZAS_DIR_CONF_FILE)` instead of `filepath.Join` — harmless on Unix, where the OS separator already is `/`, but wrong on Windows.
- `NewZasData` built `data.Path` directly from `filepath.Walk`'s own path argument, which uses the OS's native separator, with no conversion. Since `data.Path` becomes a URL rather than a filesystem path, it must always use `/` regardless of platform: on Windows, a nested page's URL would contain a literal backslash, and `IsHome`'s own hardcoded `/`-separated comparisons further down would then never match a language-prefixed home page's path either. `filepath.ToSlash` is the standard fix; the local parameter (previously also named `filepath`, shadowing the package) is renamed to `srcPath` to make room for the import.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./...` (full suite green)
- [x] `GOOS=windows GOARCH=amd64 go build ./...` and `go vet ./...` — confirm the change at least compiles and type-checks for that target, since `filepath.ToSlash` is a documented no-op wherever the OS separator is already `/` (true everywhere this repo's test suite actually runs), so the backslash-to-slash conversion itself can't be directly observed here.
- [x] New test `TestNewZasDataBuildsForwardSlashPath` pins that ordinary forward-slash paths are unaffected.
- [x] Live repro: built the `zas` binary, generated a fixture site with a nested subdirectory carrying its own `.zas.yml` (exercising the `filepath.Join` change) — URL construction and `IsHome` both correct.