### PR TITLE
docs: fix README self-contradiction on non-md/html file handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Yes, it is another NIH, but... I think Zas is a different kind of beast. I admit
 
 1. Gophers. Yes, there is [Hugo](http://gohugo.io/) (kudos!) but... Who wants to learn another directory layout? There is also [Hastie](https://github.com/mkaz/hastie) and [lots of other static site generators](https://jamstack.org/generators/).
 2. Pure Markdown. And HTML, if you want.
-3. Just a loop. Zas loops over all .md and .html files in the current directory (and subdirectories), ignoring other files (including dot-files).
+3. Just a loop. Zas loops over the current directory (and subdirectories), converting .md and .html files and copying everything else as-is - except dot-files and dot-directories, which are ignored entirely.
 4. Your imagination is your limit. Zas has a simple extension mechanism based on subcommands. Do you need to handle a blog with Zas? Install/create a new extension and do it!
 5. Unobtrusive structure, no `_` files. More in the [Usage section](#usage).
 


### PR DESCRIPTION
## Summary

README line 17 claimed Zas "ignores" any file that isn't `.md`/`.html`, while a later section (already correct) said the opposite: those files are copied into deploy as-is, alongside their directory structure — which is also what the code actually does (`renderAsync`'s default branch copies anything that isn't `.md`/`.html`, confirmed by the existing `TestGenerateProducesDeployTree` test, which asserts `assets/data.json` gets copied byte-for-byte).

Reworded line 17 to match both the code and the README's own later, accurate description, so a reader isn't left with two contradictory claims about the same behavior. Dot-files and dot-directories genuinely are ignored entirely (confirmed separately, and now correctly documented in `docs/audit/E3-dot-dir-skip-no-prune.md`'s own resolution note) — the new wording keeps that part.

## Test plan

- [x] `go build ./...` (pure docs change, unaffected)
- [x] `go test -race -count=1 ./...` (full suite green, unaffected)
- [x] Read both README passages side by side after the edit to confirm they now agree.