### PR TITLE
fix(init): stop mergo from aliasing default config sections

### DIFF
--- a/embed_containment_test.go
+++ b/embed_containment_test.go
@@ -136,7 +136,6 @@ func TestGenerateRejectsEmbedEscapingSiteRootViaAbsolutePath(t *testing.T) {
 	}
 	copyFixture(t, "site", root)
 	t.Chdir(root)
-	saveGlobals(t)
 
 	secret := filepath.Join(base, "secret.txt")
 	if err := os.WriteFile(secret, []byte("do not leak"), 0o644); err != nil {
@@ -161,7 +160,6 @@ func TestGenerateRejectsEmbedEscapingSiteRootViaTraversal(t *testing.T) {
 	}
 	copyFixture(t, "site", root)
 	t.Chdir(root)
-	saveGlobals(t)
 
 	if err := os.WriteFile(filepath.Join(base, "secret.txt"), []byte("do not leak"), 0o644); err != nil {
 		t.Fatal(err)

--- a/harness_test.go
+++ b/harness_test.go
@@ -13,15 +13,13 @@ import (
 // relative to the process's current directory, so every test here calls
 // t.Chdir and none of them can run under t.Parallel.
 
-// newTestSite copies testdata/<fixture> into a fresh temp directory, chdirs
-// into it, and snapshots ZAS_DEFAULT_CONF so a test that triggers the
-// mergo aliasing in NewConfig can't leak mutations into later tests.
+// newTestSite copies testdata/<fixture> into a fresh temp directory and
+// chdirs into it.
 func newTestSite(t *testing.T, fixture string) string {
 	t.Helper()
 	dir := t.TempDir()
 	copyFixture(t, fixture, dir)
 	t.Chdir(dir)
-	saveGlobals(t)
 	return dir
 }
 
@@ -35,32 +33,6 @@ func copyFixture(t *testing.T, fixture, dir string) {
 	if err := os.CopyFS(dir, os.DirFS(src)); err != nil {
 		t.Fatal(err)
 	}
-}
-
-// saveGlobals deep-copies ZAS_DEFAULT_CONF and restores it after the test,
-// undoing any mutation reachable through mergo's aliasing of nested config
-// sections in NewConfig.
-func saveGlobals(t *testing.T) {
-	t.Helper()
-	snapshot := deepCopyConfigSection(ZAS_DEFAULT_CONF)
-	t.Cleanup(func() {
-		ZAS_DEFAULT_CONF = snapshot
-	})
-}
-
-func deepCopyConfigSection(cs ConfigSection) ConfigSection {
-	if cs == nil {
-		return nil
-	}
-	out := make(ConfigSection, len(cs))
-	for k, v := range cs {
-		if nested, ok := v.(ConfigSection); ok {
-			out[k] = deepCopyConfigSection(nested)
-		} else {
-			out[k] = v
-		}
-	}
-	return out
 }
 
 // generate runs a full Generator.Run against the current directory.

--- a/init.go
+++ b/init.go
@@ -43,6 +43,28 @@ func NewConfig() (ConfigSection, error) {
 	if err = yaml.Unmarshal(data, &config); err != nil {
 		return nil, err
 	}
+	if config == nil {
+		config = ConfigSection{}
+	}
+	// mergo.Merge only recursively merges a nested map's own keys when
+	// dst already has a real (even if empty) map value to merge into. If
+	// a whole top-level section like "mimetypes" is absent from config,
+	// mergo instead falls back to assigning ZAS_DEFAULT_CONF's own map
+	// object for that section directly - the two configs then share the
+	// exact same underlying map, so mutating one's defaulted section
+	// (e.g. through GetSection) corrupts ZAS_DEFAULT_CONF for every
+	// subsequent NewConfig call in the process. Giving every missing
+	// section a fresh, empty map first means mergo's own merge does the
+	// actual copying, one key at a time, into a map nothing else
+	// references - no separate deep-copy logic needed.
+	for key, value := range ZAS_DEFAULT_CONF {
+		if _, ok := value.(ConfigSection); !ok {
+			continue
+		}
+		if _, exists := config[key]; !exists {
+			config[key] = ConfigSection{}
+		}
+	}
 
 	if err = mergo.Merge(&config, ZAS_DEFAULT_CONF); err != nil {
 		return nil, err

--- a/newconfig_test.go
+++ b/newconfig_test.go
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2013 Dario Castañé.
+ * This file is part of Zas.
+ *
+ * Zas is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Zas is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Zas.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package zas
+
+import (
+	"os"
+	"testing"
+)
+
+// mergo.Merge only recursively merges a nested map's own keys when dst
+// already has a real (even if empty) map value to merge into. If a whole
+// top-level section like "mimetypes" is absent from a user's config.yml
+// entirely, mergo used to fall back to assigning ZAS_DEFAULT_CONF's own
+// map object for that section directly, so mutating the returned config's
+// defaulted section (e.g. through GetSection) corrupted ZAS_DEFAULT_CONF
+// for every later NewConfig call in the process. NewConfig now pre-seeds
+// a fresh, empty map for every missing default section before merging, so
+// mergo's own recursive merge copies each value into a map nothing else
+// references - no separate deep-copy logic involved.
+
+func TestNewConfigDoesNotAliasDefaultSections(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.MkdirAll(ZAS_DIR, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// No "mimetypes" section at all - the exact case that used to alias.
+	yaml := "zas:\n  layout: .zas/layout.html\n  deploy: .zas/deploy\nsite:\n  language: en\n"
+	if err := os.WriteFile(ZAS_CONF_FILE, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := NewConfig()
+	if err != nil {
+		t.Fatalf("NewConfig() error = %v, want nil", err)
+	}
+
+	mimetypes := cfg.GetSection("mimetypes")
+	if mimetypes == nil {
+		t.Fatal(`cfg.GetSection("mimetypes") = nil, want the defaulted section`)
+	}
+	mimetypes["text/markdown"] = "corrupted"
+
+	if got := ZAS_DEFAULT_CONF.GetSection("mimetypes").GetString("text/markdown"); got != "markdown" {
+		t.Fatalf(`ZAS_DEFAULT_CONF["mimetypes"]["text/markdown"] = %q, want %q (mutating the returned config must not affect the global default)`, got, "markdown")
+	}
+
+	cfg2, err := NewConfig()
+	if err != nil {
+		t.Fatalf("second NewConfig() error = %v, want nil", err)
+	}
+	if got := cfg2.GetSection("mimetypes").GetString("text/markdown"); got != "markdown" {
+		t.Fatalf(`fresh NewConfig().GetSection("mimetypes").GetString("text/markdown") = %q, want %q`, got, "markdown")
+	}
+}
+
+// A section already present in config.yml, even partially, was never
+// affected by the aliasing bug (mergo only aliases on total absence) -
+// this pins that the fix doesn't disturb the already-correct case.
+func TestNewConfigMergesPartialSection(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.MkdirAll(ZAS_DIR, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "zas:\n  layout: .zas/layout.html\n  deploy: .zas/deploy\nmimetypes:\n  text/markdown: custom\n"
+	if err := os.WriteFile(ZAS_CONF_FILE, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := NewConfig()
+	if err != nil {
+		t.Fatalf("NewConfig() error = %v, want nil", err)
+	}
+	mimetypes := cfg.GetSection("mimetypes")
+	if got := mimetypes.GetString("text/markdown"); got != "custom" {
+		t.Fatalf(`GetSection("mimetypes").GetString("text/markdown") = %q, want the user's own value %q`, got, "custom")
+	}
+	if got := mimetypes.GetString("text/plain"); got != "plain" {
+		t.Fatalf(`GetSection("mimetypes").GetString("text/plain") = %q, want the default value %q`, got, "plain")
+	}
+}


### PR DESCRIPTION
## Summary

`mergo.Merge` only recursively merges a nested map's own keys when `dst` already has a real (even if empty) map value to merge into. If a whole top-level section like `mimetypes` was absent from a user's `config.yml` entirely, mergo fell back to assigning `ZAS_DEFAULT_CONF`'s own map object for that section directly onto the returned config — the two then shared the exact same underlying map, so mutating the returned config's defaulted section (e.g. through `GetSection`) corrupted `ZAS_DEFAULT_CONF` for every later `NewConfig` call in the process.

`NewConfig` now pre-seeds a fresh, empty `ConfigSection` for every missing default section before calling `mergo.Merge`, so mergo's own recursive merge does the actual per-key copying into a map nothing else references. No separate deep-copy logic is needed — this is exactly the aliasing-avoidance mergo was already designed to do once given a real destination map to merge into, rather than an absent key it has nothing to recurse into.

Already on `dario.cat/mergo v1.0.2`, confirmed to still be the latest v1 release (`go get -u` produced no change).

The test-only workaround this bug required — `deepCopyConfigSection` and `saveGlobals` in `harness_test.go`, snapshotting and restoring `ZAS_DEFAULT_CONF` around every generation test — is no longer needed now that the actual bug is fixed at the source, and is removed along with its two remaining call sites in `embed_containment_test.go`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./...` (full suite green, and marginally faster with the removed snapshot/restore overhead)
- [x] New tests: `TestNewConfigDoesNotAliasDefaultSections` (the exact repro — confirmed to fail against the pre-fix code with precisely the described corruption, and pass with the fix) and `TestNewConfigMergesPartialSection` (regression check that a partially-defined section, never affected by the aliasing bug, still merges correctly).
- [x] Live repro: built the `zas` binary, generated a fixture site with a `config.yml` missing the `mimetypes` section entirely — clean build, no crash.