### PR TITLE
docs: document noescape's XSS risk

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ It is plain HTML. No frills. Just add a placeholder `{{.Body}}` in your template
 
 First header level 1 from Markdown files will be made available as `{{.Title}}`, unless it is overridden.
 
+`layout.html` is parsed with Go's `html/template`, which auto-escapes values by default. A `noescape` helper is available if you need to output a string as trusted, unescaped HTML - e.g. `{{noescape .SomeTrustedHTML}}`. Only use it on content you trust: passing it anything that could contain attacker-controlled input (a value from user-submitted content, an untrusted third-party feed, etc.) reintroduces the XSS risk `html/template` exists to prevent. If you don't need it, don't use it.
+
 ### But... I want to do pages beyond post-like format
 
 No problem! Just use our old friend `<embed>`. Imagine `<layout>` is a valid tag.


### PR DESCRIPTION
## Summary

`layout.html`'s `FuncMap` registers `noescape`, converting a string to trusted HTML and bypassing `html/template`'s contextual auto-escaping — a deliberate escape hatch, but one the README never mentioned.

Added a short paragraph explaining what it does and when it's safe to use: only on content you already trust, since passing it anything attacker-controlled reintroduces the XSS risk `html/template` exists to prevent.

## Test plan

- [x] `go build ./...` (pure docs change, unaffected)
- [x] `go test -race -count=1 ./...` (full suite green, unaffected)
- [x] Read the new paragraph in context to confirm it fits the README's existing tone and placement (right after the `layout.html` section that already covers `{{.Body}}`/`{{.Title}}`).