### PR TITLE
feat(zas): add NewGenerator constructor, document copy hazard

### DIFF
--- a/cmd/zas/main.go
+++ b/cmd/zas/main.go
@@ -47,11 +47,7 @@ var (
 		return i.Run()
 	})
 	cmdGenerate = zas.NewSubcommand("generate - render the site from source into the deploy directory", func() error {
-		g := zas.Generator{
-			Verbose: *verbose,
-			Full:    *full,
-		}
-		return g.Run()
+		return zas.NewGenerator(*verbose, *full).Run()
 	})
 	// cmdHelp and cmdVersion get their Run funcs wired up in init() below,
 	// rather than inline here: both printUsage and printVersion end up

--- a/generate.go
+++ b/generate.go
@@ -113,13 +113,29 @@ var markdownConverter = markdown.New(
 	),
 )
 
-// Generator groups relevant rendering info.
+// NewGenerator returns a Generator ready to Run with the given verbosity
+// and full-generation settings.
+func NewGenerator(verbose, full bool) *Generator {
+	return &Generator{
+		Verbose: verbose,
+		Full:    full,
+	}
+}
+
+// Generator groups relevant rendering info. Like sync.WaitGroup, which it
+// embeds, a Generator must not be copied after it has been constructed -
+// use NewGenerator, or a Generator{} literal, and refer to it thereafter
+// only by pointer.
 type Generator struct {
 	// Verbose output.
 	Verbose bool
 	// Full generation (non-incremental mode).
 	Full bool
-	// Config from ConfigFile.
+	// Config holds the site configuration. Run always overwrites it with
+	// the freshly loaded contents of ConfigFile, so setting it before
+	// calling Run has no effect on Run itself; it's only meaningful when
+	// calling Generator's other methods directly without going through
+	// Run.
 	Config ConfigSection
 	// Default layout from Config[Name]["layout"].
 	Layout *thtml.Template

--- a/generator_test.go
+++ b/generator_test.go
@@ -1,0 +1,21 @@
+package zas
+
+import "testing"
+
+func TestNewGeneratorSetsVerboseAndFull(t *testing.T) {
+	gen := NewGenerator(true, true)
+	if !gen.Verbose {
+		t.Error("NewGenerator(true, true).Verbose = false, want true")
+	}
+	if !gen.Full {
+		t.Error("NewGenerator(true, true).Full = false, want true")
+	}
+
+	gen = NewGenerator(false, false)
+	if gen.Verbose {
+		t.Error("NewGenerator(false, false).Verbose = true, want false")
+	}
+	if gen.Full {
+		t.Error("NewGenerator(false, false).Full = true, want false")
+	}
+}


### PR DESCRIPTION
## What this fixes

`Generator` is exported, constructible by literal from any importing package, and embeds several `sync.Mutex`/`sync.WaitGroup` fields by value. Nothing warned callers that copying a `Generator` after construction (assignment, a by-value function argument, a range copy) is a `go vet copylocks` violation waiting to happen, and there was no constructor pointing toward the safe, by-pointer usage the type actually requires.

## The fix

- Added `NewGenerator(verbose, full bool) *Generator`, an idiomatic construction path.
- `Generator`'s own doc comment now says plainly, the same way `sync.WaitGroup`'s does, that it must not be copied after construction.
- Documented a related point of confusion: `Run` unconditionally overwrites the exported `Config` field with `ConfigFile`'s freshly loaded contents, so setting `Config` before calling `Run` has no effect on `Run` itself - it only matters for callers that invoke `Generator`'s other methods directly instead of going through `Run`. The field's doc comment now says so.
- `cmd/zas/main.go`'s `generate` subcommand now goes through `NewGenerator` instead of a `Generator{}` literal.

## Why not a deeper restructuring

An alternative fix would move every lock/cache field into a separate unexported struct referenced through a pointer, eliminating the copylocks hazard structurally rather than just documenting it. That's a much larger, more invasive change (touches every method that reads those fields, plus several tests that reach into internal fields like `gen.wg`/`gen.peakActive` directly), disproportionate to this finding's low severity. The chosen fix mirrors exactly how the standard library documents the same situation (`sync.WaitGroup`, `bytes.Buffer`, `strings.Builder`: "must not be copied after first use," discoverable via `go vet`) rather than reinventing the type's shape.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./...` (all passing, including a new `TestNewGeneratorSetsVerboseAndFull`)
- [x] Built the `zas` binary and ran `zas init` + `zas generate` against a fresh fixture site through the new `NewGenerator` path - correct output