### PR TITLE
ci: add goreleaser-based release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    name: GoReleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          check-latest: true
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,9 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      # Strict semver only (v1.2.3) - not "v*", which would also fire on
+      # any other tag starting with "v" (v-test, vNext, version-2, ...).
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 permissions:
   contents: write

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,69 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+project_name: zas
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: zas
+    main: ./cmd/zas
+    binary: zas
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - arm64
+      - amd64
+    ldflags:
+      - -s -w
+
+archives:
+  - id: zas
+    formats: [tar.gz]
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "^chore:"
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      order: 0
+    - title: "Bug fixes"
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: Others
+      order: 999
+
+release:
+  footer: >-
+
+    ---
+
+    Released by [GoReleaser](https://github.com/goreleaser/goreleaser).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,3 +98,25 @@ dynamically (a loop writing hundreds of files, `os.Chmod` to force a
 permission error, etc.) stays in the test or helper function - a fixture is
 for content a maintainer would want to read as-is, not a place to encode
 logic.
+
+## Releasing
+
+Pushing a tag matching `v*` (e.g. `v0.1.0`) triggers
+`.github/workflows/release.yml`, which runs
+[GoReleaser](https://goreleaser.com) (config in `.goreleaser.yaml`) to build
+`cmd/zas` for linux/darwin/windows on amd64/arm64, archive and checksum the
+binaries, generate a changelog grouped by commit type from the Conventional
+Commits history since the previous tag, and publish all of it as a GitHub
+Release. `zas version`'s own output (see `cmd/zas/main.go`) needs no extra
+wiring for this - it already reads the module version and VCS revision Go's
+toolchain stamps into the binary at build time.
+
+To try the whole pipeline locally without publishing anything, install
+[goreleaser](https://goreleaser.com/install/) and run:
+
+```sh
+goreleaser release --snapshot --skip=publish --clean
+```
+
+This is a plain binary+checksum+changelog release; packaging for a package
+manager (Homebrew, apt, etc.) isn't set up yet.


### PR DESCRIPTION
## What this fixes

Release automation existed once (`.goreleaser.yml`, added 2019, later deleted) but nothing replaced it: tags stop at `v0.0.6`, there's no changelog, and no binary release has ever been published. `go install` still works and stays fully supported, but H1 and H2 just shipped this repo's first real breaking API changes with no release process to signal that to library consumers, and running a static site generator via `go install` alone shuts out anyone without a Go toolchain.

## The fix

- `.goreleaser.yaml` (v2 schema): builds `cmd/zas` for linux/darwin/windows on amd64/arm64, archives and checksums the binaries, and generates a changelog grouped by commit type (feat/fix/other) from the Conventional Commits history this repo already follows.
- `.github/workflows/release.yml`: pushing a tag matching `v*` runs GoReleaser and publishes everything as a GitHub Release.
- `CONTRIBUTING.md`: documents the release process and how to dry-run it locally.

`zas version`'s existing output needs no changes to work with this - it already reads the module version and VCS revision Go's own toolchain stamps into the binary (D4), which a GoReleaser-built binary carries the same as any plain `go build`.

## Deliberately out of scope

Homebrew (or any other package-manager) packaging isn't set up. GoReleaser supports it via a `brews:` block, but that needs a separate tap repository and its own access token secret - a bigger commitment than closing this specific gap warrants today. Can be added later against an actual tagged release.

**No tag is pushed and no release is triggered by this PR.** The workflow only fires on a future `v*` tag push, which still needs separate authorization to actually cut a release.

## Test plan

- [x] `go build ./...` / `go vet ./...` / `gofmt -l .` (clean) / `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./...` (all passing, unaffected by this change)
- [x] `actionlint .github/workflows/release.yml` (clean)
- [x] `goreleaser check` (config validates)
- [x] `goreleaser release --snapshot --skip=publish --clean` locally: all six platform archives build successfully; extracted the Linux binary and ran `zas version` - correct output, no publish/tag side effects