### PR TITLE
feat(zas): add -no-plugins flag, document the plugin trust model

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ Maybe you are asking yourself: "Where is mzsmarkdown?". Nowhere! It is a particu
 
 If you develop a new plugin, please contact me, and I will list it here :) Please, keep in mind: make it [idempotent](http://en.wikipedia.org/wiki/Idempotence).
 
+#### Plugin trust model
+
+Both plugin mechanisms resolve a name to a binary on `PATH` and execute it - Zas does no sandboxing, signing, or verification of what it finds there. That's a deliberate design, in the same spirit as how `git <subcommand>` resolves to `git-<subcommand>` on `PATH`, but it's worth being explicit about the two different ways a plugin name gets chosen:
+
+- **`zas <name>` subcommand plugins** are only ever invoked from a name you (or a script you wrote) typed directly as a command-line argument - the same trust level as running any other program by name in your shell.
+- **`mzs*` MIME type plugins** are chosen by `mimetypes:` config and triggered by `<embed type="...">` tags found in site *content*. If you ever run `zas generate` over content you don't fully control - a preview build from an external contribution, for example - that content effectively gets to pick which already-installed plugin binary runs, with the embed's `src` as an argument.
+
+If that second case applies to you, pass `-no-plugins` to `zas generate`: any embed that would need an external MIME type plugin fails with a clear error instead of executing anything (Zas's own built-in embed handlers, like Markdown, aren't affected - they never spawn a process).
+
 ## Building sites
 
 Your site layout will look like this:

--- a/cmd/zas/main.go
+++ b/cmd/zas/main.go
@@ -41,13 +41,13 @@ var subcommands = []*zas.Subcommand{
 }
 
 var (
-	verbose, full *bool
-	cmdInit       = zas.NewSubcommand("init - create a new Zas site in the current directory", func() error {
+	verbose, full, noPlugins *bool
+	cmdInit                  = zas.NewSubcommand("init - create a new Zas site in the current directory", func() error {
 		i := zas.Init{}
 		return i.Run()
 	})
 	cmdGenerate = zas.NewSubcommand("generate - render the site from source into the deploy directory", func() error {
-		return zas.NewGenerator(*verbose, *full).Run()
+		return zas.NewGenerator(*verbose, *full, *noPlugins).Run()
 	})
 	// cmdHelp and cmdVersion get their Run funcs wired up in init() below,
 	// rather than inline here: both printUsage and printVersion end up
@@ -63,6 +63,7 @@ var (
 func init() {
 	verbose = cmdGenerate.Flag.Bool("verbose", false, "Verbose output")
 	full = cmdGenerate.Flag.Bool("full", false, "Full generation (non-incremental mode)")
+	noPlugins = cmdGenerate.Flag.Bool("no-plugins", false, "Disable content-triggered MIME-type plugin execution (see README's \"Plugins\" section)")
 
 	cmdHelp.Run = func() error {
 		printUsage(os.Stdout)

--- a/generate.go
+++ b/generate.go
@@ -113,12 +113,13 @@ var markdownConverter = markdown.New(
 	),
 )
 
-// NewGenerator returns a Generator ready to Run with the given verbosity
-// and full-generation settings.
-func NewGenerator(verbose, full bool) *Generator {
+// NewGenerator returns a Generator ready to Run with the given verbosity,
+// full-generation, and plugin-execution settings.
+func NewGenerator(verbose, full, noPlugins bool) *Generator {
 	return &Generator{
-		Verbose: verbose,
-		Full:    full,
+		Verbose:   verbose,
+		Full:      full,
+		NoPlugins: noPlugins,
 	}
 }
 
@@ -131,6 +132,17 @@ type Generator struct {
 	Verbose bool
 	// Full generation (non-incremental mode).
 	Full bool
+	// NoPlugins disables content-triggered MIME-type plugin execution (see
+	// handleMIMETypePlugin): an embed that resolves to an external plugin
+	// fails with a clear per-page error instead of exec'ing anything. It
+	// has no effect on zas's own internal embed handlers (Markdown, Plain,
+	// Html), which never spawn a process, or on the separate zs<name>
+	// subcommand-plugin mechanism cmd/zas dispatches directly from argv -
+	// that path only ever fires from a name the invoking user typed
+	// themselves, not from site content. Set this when generating from
+	// content you don't fully control (see README's "Plugins" section for
+	// the full trust model this guards).
+	NoPlugins bool
 	// Config holds the site configuration. Run always overwrites it with
 	// the freshly loaded contents of ConfigFile, so setting it before
 	// calling Run has no effect on Run itself; it's only meaningful when
@@ -1486,6 +1498,9 @@ func (gen *Generator) handleMIMETypePlugin(e *goquery.Selection) error {
 	cmdname := gen.resolveMIMETypePlugin(typ)
 	if !pluginNameRe.MatchString(cmdname) {
 		return fmt.Errorf("no valid plugin configured for embed type %q (src %q)", typ, src)
+	}
+	if gen.NoPlugins {
+		return fmt.Errorf("plugin execution disabled (-no-plugins): embed type %q (src %q) needs plugin m%s%s", typ, src, PluginPrefix, cmdname)
 	}
 	cmd := exec.Command(fmt.Sprintf("m%s%s", PluginPrefix, cmdname), src)
 	cmd.Stderr = os.Stderr

--- a/generator_test.go
+++ b/generator_test.go
@@ -3,19 +3,25 @@ package zas
 import "testing"
 
 func TestNewGeneratorSetsVerboseAndFull(t *testing.T) {
-	gen := NewGenerator(true, true)
+	gen := NewGenerator(true, true, true)
 	if !gen.Verbose {
-		t.Error("NewGenerator(true, true).Verbose = false, want true")
+		t.Error("NewGenerator(true, true, true).Verbose = false, want true")
 	}
 	if !gen.Full {
-		t.Error("NewGenerator(true, true).Full = false, want true")
+		t.Error("NewGenerator(true, true, true).Full = false, want true")
+	}
+	if !gen.NoPlugins {
+		t.Error("NewGenerator(true, true, true).NoPlugins = false, want true")
 	}
 
-	gen = NewGenerator(false, false)
+	gen = NewGenerator(false, false, false)
 	if gen.Verbose {
-		t.Error("NewGenerator(false, false).Verbose = true, want false")
+		t.Error("NewGenerator(false, false, false).Verbose = true, want false")
 	}
 	if gen.Full {
-		t.Error("NewGenerator(false, false).Full = true, want false")
+		t.Error("NewGenerator(false, false, false).Full = true, want false")
+	}
+	if gen.NoPlugins {
+		t.Error("NewGenerator(false, false, false).NoPlugins = true, want false")
 	}
 }

--- a/mime_plugin_test.go
+++ b/mime_plugin_test.go
@@ -87,3 +87,36 @@ func TestHandleMIMETypePluginRejectsPathSeparator(t *testing.T) {
 		t.Fatalf("error = %v, want the name rejected before exec", err)
 	}
 }
+
+func TestHandleMIMETypePluginNoPluginsRefusesToExec(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script plugin stub is not portable to windows")
+	}
+	bin := t.TempDir()
+	script := "#!/bin/sh\necho '<b>ok</b>'\n"
+	if err := os.WriteFile(filepath.Join(bin, "mzstest"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin)
+
+	gen := &Generator{
+		NoPlugins: true,
+		Config: ConfigSection{
+			"mimetypes": ConfigSection{"text/x-test": "test"},
+		},
+	}
+	doc := newEmbedDoc(t, "x", "text/x-test")
+	err := gen.handleMIMETypePlugin(doc.Find("embed"))
+	if err == nil {
+		t.Fatal("handleMIMETypePlugin() with NoPlugins set: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "-no-plugins") {
+		t.Fatalf("error = %v, want it to mention -no-plugins", err)
+	}
+	// The binary really is on PATH and would have worked (see
+	// TestHandleMIMETypePluginRunsExternalCommand) - NoPlugins must refuse
+	// before exec, not because the plugin was otherwise unusable.
+	if doc.Find("embed").Length() != 1 {
+		t.Fatal("embed tag was replaced despite NoPlugins - plugin executed anyway")
+	}
+}


### PR DESCRIPTION
## What this addresses

Both of zas's plugin mechanisms resolve a name to a binary on `PATH` and exec it, with no sandboxing or verification. The `zas <name>` subcommand path only ever fires from an argument the invoking user typed themselves. The `mzs*` MIME-type path is different: it's chosen by `mimetypes:` config and triggered by `<embed type="...">` tags in *site content* - meaning generating from content you don't fully control (a preview build from an external contribution, say) lets that content pick which already-installed plugin binary runs. Nothing in the README documented this, and there was no way to opt out short of removing every `mzs*` binary from `PATH`.

## The fix

- `Generator` gains a `NoPlugins` field (`NewGenerator`'s third parameter, alongside `verbose` and `full`); `cmd/zas` exposes it as `generate -no-plugins`.
- `handleMIMETypePlugin` now refuses to exec when `NoPlugins` is set, failing with a clear per-page error naming the embed's type, src, and the plugin it would have run - the same graceful, per-page degradation this codebase's other embed errors already use, not a hard abort of the whole run.
- No effect on zas's own internal embed handlers (`Markdown`, `Plain`, `Html`) - they never spawn a process - and no effect on the argv-driven subcommand path, which isn't content-triggered.
- README's "Plugins" section gains a "Plugin trust model" subsection explaining the distinction and when to reach for `-no-plugins`.

## Test plan

- [x] `go build ./...` / `go vet ./...` / `gofmt -l .` (clean) / `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./...` (all passing, including a new `TestHandleMIMETypePluginNoPluginsRefusesToExec`)
- [x] Live repro: built the binary, configured a real `mzshello` plugin on `PATH`, confirmed it runs normally without the flag and is cleanly refused (exit 1, clear error, embed left untouched) with `-no-plugins`
- [x] `zas generate -h` lists the new flag with its description