### PR TITLE
docs(zas): explain and cover the double-parse pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,12 @@ What does it mean? It means you can have .html files with embedded markdown file
 
 Zas still reads and processes `navigation.md` normally wherever it's embedded, but it won't also show up on its own at `/navigation.html` in the deploy output.
 
+`<embed>` also works directly inside `layout.html` itself, not just inside a page's own body - useful for something every page shares, like a site-wide footer.
+
+#### A note on output vs. source
+
+Every page goes through Zas's HTML5 parser twice: once on its own, to extract its body and settings, and once more after the layout wraps it, so any `<embed>` in the layout itself gets its turn too. Both passes re-serialize what they parse, and HTML5's parser is lenient by design - it repairs markup as it goes rather than rejecting it - so deployed output can differ mechanically from what you wrote: attributes get quoted, tag names get lowercased, void elements like `<img>`/`<br>` get self-closed, stray `&` characters get entity-escaped. Nothing is lost, and this is also why the embed mechanism above can splice arbitrary snippets together reliably - but don't expect deployed HTML to be a byte-for-byte copy of your source.
+
 ## 你会说普通话?
 
 對不起。T我不会说普通话。That's all my Chinese! If you are here, I guess you will enjoy I18N support in Zas.

--- a/generate.go
+++ b/generate.go
@@ -367,6 +367,23 @@ func (gen *Generator) Generate(_ string, data *ZasData) (err error) {
 	if err = gen.Layout.Execute(&processed, data); err != nil {
 		return
 	}
+	// This parseAndReplace is a second full HTML5 parse of the page - render
+	// already ran one over the page's own source to produce data.Body. It's
+	// not redundant: render's parse only ever sees the page's own markup, so
+	// an <embed> written directly into layout.html itself (outside
+	// {{.Body}}, e.g. a site-wide footer) is invisible to it and can only
+	// resolve here, against the fully assembled layout+body page (see
+	// TestGenerateResolvesEmbedInLayoutItself). html/template also has no
+	// notion of a parsed tree to merge the two passes' output into - it
+	// only ever produces bytes - so there's no cheaper way to give this
+	// pass's embed handling a shot at the assembled page than re-parsing
+	// it whole. Re-serializing through html5.Render below is also why
+	// deployed output isn't guaranteed byte-identical to what either the
+	// page or the layout wrote: HTML5's parser normalizes as it goes
+	// (attribute quoting, tag casing, void-element closing, entity
+	// escaping) - the embed mechanism actually depends on that leniency
+	// today (see F5-embed-injects-body-html.md), so this isn't a candidate
+	// for a stricter, non-repairing parse either.
 	doc, err := gen.parseAndReplace(&processed, data)
 	if err != nil {
 		return

--- a/layout_embed_test.go
+++ b/layout_embed_test.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2013 Dario Castañé.
+ * This file is part of Zas.
+ *
+ * Zas is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Zas is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Zas.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package zas
+
+import (
+	"strings"
+	"testing"
+)
+
+// render only ever parses a page's own source. An <embed> tag written
+// directly into layout.html - outside {{.Body}} - is never seen by that
+// parse; the only place it can resolve is Generate's second parseAndReplace
+// pass over the fully assembled page (layout + body). This pins that the
+// second pass is load-bearing, not redundant work: dropping it, or
+// replacing it with something that only walks the page's own body, would
+// silently stop layout-level embeds from working.
+//
+// This assertion is deliberately loose about exact markup shape: Html's
+// handler (generate.go) splices in the embedded file's whole parsed
+// document - <html><head>...<body>... - rather than just its body's
+// contents, same pre-existing gap F5 (F5-embed-injects-body-html.md)
+// already tracks for page-body-level embeds. Page-body embeds only look
+// clean today because they get a second, further re-parse (this same
+// Generate pass) whose HTML5 error recovery quietly drops the duplicate
+// html/body tags; a layout-level embed like this one has no such further
+// pass to hide behind, so the nesting survives into deployed output
+// verbatim - confirmed live and noted on F5's own file. Once F5's
+// remaining sub-claims land, this test should keep passing unchanged and
+// could be tightened to assert the exact clean markup.
+func TestGenerateResolvesEmbedInLayoutItself(t *testing.T) {
+	newTestSite(t, "layout-embed-site")
+	if err := generate(t); err != nil {
+		t.Fatalf("generate() error = %v, want nil", err)
+	}
+	got := readDeploy(t, "index.html")
+	if !strings.Contains(got, "footer from the layout itself") {
+		t.Fatalf("deployed index.html = %q, want it to contain the layout's own embedded footer", got)
+	}
+	if strings.Contains(got, "<embed") {
+		t.Fatalf("deployed index.html = %q, want the layout's <embed> tag replaced, not left in place", got)
+	}
+}

--- a/testdata/layout-embed-site/.zas/config.yml
+++ b/testdata/layout-embed-site/.zas/config.yml
@@ -1,0 +1,6 @@
+zas:
+  layout: .zas/layout.html
+  deploy: .zas/deploy
+site:
+  baseurl: http://example.com
+  language: en

--- a/testdata/layout-embed-site/.zas/layout.html
+++ b/testdata/layout-embed-site/.zas/layout.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head><title>{{.Title}}</title></head>
+<body>
+{{.Body}}
+<embed src="footer.html" type="text/html">
+</body>
+</html>

--- a/testdata/layout-embed-site/footer.html
+++ b/testdata/layout-embed-site/footer.html
@@ -1,0 +1,2 @@
+<!-- publish: false -->
+<footer id="site-footer">footer from the layout itself</footer>

--- a/testdata/layout-embed-site/index.html
+++ b/testdata/layout-embed-site/index.html
@@ -1,0 +1,2 @@
+<!-- title: Home -->
+<p>page content</p>


### PR DESCRIPTION
## What this addresses

Every page runs through a full HTML5 parse-and-serialize pass twice: once in `render`, over the page's own source, and once more in `Generate`, over the fully assembled layout+body page. Nothing explained why, and the second pass's side effect - HTML5's parser repairs markup as it reserializes, so deployed output can differ mechanically from what was written - was undocumented and easy to mistake for a bug.

## Why not remove the double-parse

Considered and rejected as unsafe: added a regression test (`TestGenerateResolvesEmbedInLayoutItself`) proving the second pass does real work, not just repeated work. An `<embed>` written directly into `layout.html` (outside `{{.Body}}`) is invisible to `render`'s parse, which only ever sees a page's own source - it can only resolve against `Generate`'s parse of the fully assembled page. `html/template` also has no notion of a parsed tree to merge the two passes into; it only ever produces bytes, so there's no cheaper way to give the second pass's embed handling a shot at the assembled page than re-parsing it whole.

## The fix

Pure documentation + test coverage, no pipeline changes:
- A comment on `Generate`'s second `parseAndReplace` call explaining why it exists and why the output-differs-from-source behavior isn't a bug.
- A new README subsection ("A note on output vs. source") explaining the same for anyone surprised by it, plus a one-line mention that `<embed>` works inside `layout.html` itself.
- `TestGenerateResolvesEmbedInLayoutItself` + a new `testdata/layout-embed-site` fixture, proving the layout-level embed case live.

## A separate issue this surfaced

Writing that regression test surfaced concrete new evidence for an already-tracked, separate issue: the `Html` embed handler splices in the embedded file's whole parsed document (`<html><head>...<body>...`) instead of just its body content. This normally goes unnoticed for a page-body-level embed because a further whole-page re-parse's HTML5 error recovery quietly drops the duplicate tags - but a layout-level embed has no further re-parse to hide behind, so the nesting artifact survives into deployed output as-is. That's a distinct, already-partially-resolved issue with its own scope; this PR's own test asserts today's actual (imperfect) behavior rather than papering over it, with a comment explaining why. Flagged separately rather than folded into this PR.

## Test plan

- [x] `go build ./...` / `go vet ./...` / `gofmt -l .` (clean) / `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./...` (all passing, including the new test)
- [x] Live repro: built the binary, generated the new fixture, confirmed the layout's own embedded footer appears in deployed output