### PR TITLE
fix(generate): splice embedded content, not the wrapping element

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -381,9 +381,8 @@ func (gen *Generator) Generate(_ string, data *ZasData) (err error) {
 	// deployed output isn't guaranteed byte-identical to what either the
 	// page or the layout wrote: HTML5's parser normalizes as it goes
 	// (attribute quoting, tag casing, void-element closing, entity
-	// escaping) - the embed mechanism actually depends on that leniency
-	// today (see F5-embed-injects-body-html.md), so this isn't a candidate
-	// for a stricter, non-repairing parse either.
+	// escaping), so this isn't a candidate for a stricter, non-repairing
+	// parse.
 	doc, err := gen.parseAndReplace(&processed, data)
 	if err != nil {
 		return
@@ -1373,7 +1372,15 @@ func (gen *Generator) Markdown(e *goquery.Selection, _ *goquery.Document, data *
 		if err != nil {
 			return err
 		}
-		e.ReplaceWithSelection(mdDoc.Find(atom.Body.String()))
+		// Contents(), not the body Selection itself: splicing in the <body>
+		// element would nest a second body inside the host page. Only a
+		// page-body-level embed used to get away with this, because
+		// Generate's own re-parse of the fully assembled page silently
+		// dropped the resulting duplicate body tag via HTML5 error recovery
+		// - an embed anywhere else (e.g. written directly into layout.html)
+		// has no further parse to hide behind, so the nesting survived into
+		// deployed output.
+		e.ReplaceWithSelection(mdDoc.Find(atom.Body.String()).Contents())
 	}
 	return
 }
@@ -1421,7 +1428,16 @@ func (gen *Generator) Html(e *goquery.Selection, _ *goquery.Document, data *ZasD
 		if err != nil {
 			return err
 		}
-		e.ReplaceWithSelection(htmlDoc.Children())
+		// htmlDoc.Children() would give the parsed <html> element itself
+		// (the document node's only child), nesting a whole
+		// <html><head>...<body>... structure - including the embedded
+		// file's own <head> content (title/meta/style) - into the host
+		// page. Find the embedded body and take only its Contents(),
+		// dropping the embedded file's <head> entirely: there's no
+		// principled place in the host page to merge title/meta/style tags
+		// from an arbitrary embed point, and the host page's own <head> is
+		// long since rendered and gone by the time an embed resolves.
+		e.ReplaceWithSelection(htmlDoc.Find(atom.Body.String()).Contents())
 	}
 	return
 }

--- a/layout_embed_test.go
+++ b/layout_embed_test.go
@@ -31,18 +31,12 @@ import (
 // replacing it with something that only walks the page's own body, would
 // silently stop layout-level embeds from working.
 //
-// This assertion is deliberately loose about exact markup shape: Html's
-// handler (generate.go) splices in the embedded file's whole parsed
-// document - <html><head>...<body>... - rather than just its body's
-// contents, same pre-existing gap F5 (F5-embed-injects-body-html.md)
-// already tracks for page-body-level embeds. Page-body embeds only look
-// clean today because they get a second, further re-parse (this same
-// Generate pass) whose HTML5 error recovery quietly drops the duplicate
-// html/body tags; a layout-level embed like this one has no such further
-// pass to hide behind, so the nesting survives into deployed output
-// verbatim - confirmed live and noted on F5's own file. Once F5's
-// remaining sub-claims land, this test should keep passing unchanged and
-// could be tightened to assert the exact clean markup.
+// Html's handler (generate.go) splices in only the embedded file's body
+// contents, not its whole parsed document, so a layout-level embed like
+// this one - which has no further re-parse downstream to paper over a
+// nesting mistake - must still deploy with exactly the outer page's own
+// single <html>/<head>/<body>, not a second, stray one nested from the
+// embedded document.
 func TestGenerateResolvesEmbedInLayoutItself(t *testing.T) {
 	newTestSite(t, "layout-embed-site")
 	if err := generate(t); err != nil {
@@ -54,5 +48,10 @@ func TestGenerateResolvesEmbedInLayoutItself(t *testing.T) {
 	}
 	if strings.Contains(got, "<embed") {
 		t.Fatalf("deployed index.html = %q, want the layout's <embed> tag replaced, not left in place", got)
+	}
+	for _, tag := range []string{"<html", "<head", "<body"} {
+		if n := strings.Count(got, tag); n != 1 {
+			t.Fatalf("deployed index.html = %q, want exactly one %q (the outer page's own), got %d", got, tag, n)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

`Markdown`'s and `Html`'s embed handlers replaced an `<embed>` tag with
the embedded document's whole `<body>`/`<html>` *element*, nesting a
second body (or a whole html/head/body tree, including the embedded
file's own `<title>`/`<meta>`/`<style>`) inside the host page. This only
ever looked clean for a page-body-level embed, because `Generate`'s own
re-parse of the fully assembled page silently dropped the resulting
duplicate tags via HTML5's error-recovery rules — an embed anywhere
else (e.g. written directly into `layout.html`) has no such further
parse to hide behind, and the nesting artifact survived into deployed
output verbatim.

- `Markdown` now takes `mdDoc.Find("body").Contents()` instead of the
  `<body>` selection itself.
- `Html` now takes `htmlDoc.Find("body").Contents()` instead of
  `htmlDoc.Children()` (the parsed `<html>` element). The embedded
  file's `<head>` is dropped entirely — there is no principled place in
  the host page to merge title/meta/style tags from an arbitrary embed
  point.
- As a side effect, an embedded body's own attributes (`id`, `data-*`,
  ...) no longer leak onto the host body — they used to, but only via
  the same accidental duplicate-tag merge, not through any deliberate
  mechanism. Preserving that behavior on purpose would need a merge
  target this fix doesn't have (unlike the top-level page-to-layout
  `bodyAttrs` merge, which always has exactly one destination); treated
  as out of scope here.
- `TestGenerateResolvesEmbedInLayoutItself` is tightened to assert the
  deployed page has exactly one `html`/`head`/`body` tag, not just that
  the embed resolved at all.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./...`
- [x] Live binary repro: built `zas`, ran `-full` over `testdata/site`
      (page-body-level `Html` embed) and `testdata/layout-embed-site`
      (layout-level embed) — both deploy with clean, non-nested markup.
- [x] Live binary repro of the original head/body-nesting scenario (a
      full HTML doc with `<title>`/`<meta>`/`<style>` and a `<body
      id="..." data-embedded="yes">` embedded into a host page) —
      deploys clean, no head content mid-body, no duplicate body/html,
      no leaked attributes.