### PR TITLE
fix(zas)!: migrate ConfigSection to map[string]interface{}

### DIFF
--- a/configsection_test.go
+++ b/configsection_test.go
@@ -34,10 +34,11 @@ func TestGetSectionScalarValue(t *testing.T) {
 }
 
 func TestGetSectionRawYAMLMap(t *testing.T) {
-	// ConfigSection.UnmarshalYAML normalizes decoded nested sections to
-	// ConfigSection, but GetSection must still recognize a raw
-	// map[interface{}]interface{} for any section built by other means.
-	cs := ConfigSection{"site": map[interface{}]interface{}{"language": "en"}}
+	// go.yaml.in/yaml/v3 decodes every nested section into ConfigSection
+	// itself (see the type's doc comment in init.go), but GetSection must
+	// still recognize a raw map[string]interface{} for any section built
+	// by other means, e.g. a caller constructing one by hand.
+	cs := ConfigSection{"site": map[string]interface{}{"language": "en"}}
 	section := cs.GetSection("site")
 	if section == nil {
 		t.Fatal("GetSection() = nil, want a section")

--- a/init.go
+++ b/init.go
@@ -28,50 +28,19 @@ import (
 	yaml "go.yaml.in/yaml/v3"
 )
 
-// ConfigSection aliases goyaml's default map type.
-type ConfigSection map[interface{}]interface{}
-
-// UnmarshalYAML normalizes decoded mappings to ConfigSection at every
-// nesting level. go.yaml.in/yaml (unlike gopkg.in/yaml.v2) decodes a
-// mapping into an interface{} field as map[string]interface{}, not this
-// package's own map[interface{}]interface{} alias - without this,
-// GetSection's type switch would silently miss every subsection loaded
-// from a real YAML file, and mergo.Merge panics merging a decoded
-// map[string]interface{} against DefaultConfig's ConfigSection values.
-func (cs *ConfigSection) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var raw map[string]interface{}
-	if err := unmarshal(&raw); err != nil {
-		return err
-	}
-	out := make(ConfigSection, len(raw))
-	for key, value := range raw {
-		out[key] = normalizeConfigValue(value)
-	}
-	*cs = out
-	return nil
-}
-
-// normalizeConfigValue recursively converts any map[string]interface{}
-// produced by YAML decoding into ConfigSection, so GetSection recognizes
-// subsections regardless of nesting depth.
-func normalizeConfigValue(value interface{}) interface{} {
-	switch v := value.(type) {
-	case map[string]interface{}:
-		out := make(ConfigSection, len(v))
-		for key, item := range v {
-			out[key] = normalizeConfigValue(item)
-		}
-		return out
-	case []interface{}:
-		out := make([]interface{}, len(v))
-		for i, item := range v {
-			out[i] = normalizeConfigValue(item)
-		}
-		return out
-	default:
-		return value
-	}
-}
+// ConfigSection is a section of zas configuration: a string-keyed map,
+// as produced by decoding a YAML mapping and by every ConfigSection{...}
+// literal in this package. go.yaml.in/yaml/v3 special-cases a named map
+// type whose keys are strings and whose values are interface{}: once it
+// decodes the outermost mapping into a ConfigSection, it keeps using that
+// same named type for every nested mapping found inside an interface{}
+// value, at any depth (see stringMapType propagation in its decoder) -
+// so a config.yml with several levels of nested sections decodes into
+// nested ConfigSection values all the way down, with no custom
+// UnmarshalYAML method required. (That propagation requires every key in
+// the mapping to be a string; GetSection's map[string]interface{}
+// fallback below covers a section that arrives some other way.)
+type ConfigSection map[string]interface{}
 
 // NewConfig loads ConfigFile (as defined in constants.go).
 // It must be a YAML file.
@@ -154,7 +123,11 @@ func (cs ConfigSection) GetSection(key string) (value ConfigSection) {
 	switch raw := cs[key].(type) {
 	case ConfigSection:
 		value = raw
-	case map[interface{}]interface{}:
+	case map[string]interface{}:
+		// A section built by some means other than decoding YAML into a
+		// ConfigSection-typed destination (e.g. a caller constructing one
+		// by hand as a plain map[string]interface{}) - see
+		// TestGetSectionRawYAMLMap.
 		value = ConfigSection(raw)
 	}
 	return

--- a/newconfig_test.go
+++ b/newconfig_test.go
@@ -95,3 +95,62 @@ func TestNewConfigMergesPartialSection(t *testing.T) {
 		t.Fatalf(`GetSection("mimetypes").GetString("text/plain") = %q, want the default value %q`, got, "plain")
 	}
 }
+
+// GetSection must recognize a subsection as a section regardless of how
+// deeply it is nested. go.yaml.in/yaml/v3 only keeps decoding nested
+// mappings into the named ConfigSection type (rather than some other map
+// type GetSection wouldn't recognize) by propagating that named type
+// downward from the enclosing map on every decode - a bug here would
+// typically only show up two or more levels deep, since the outermost
+// mapping always decodes correctly on its own.
+func TestNewConfigNestedSections(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.MkdirAll(Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "zas:\n" +
+		"  layout: .zas/layout.html\n" +
+		"  deploy: .zas/deploy\n" +
+		"site:\n" +
+		"  language: en\n" +
+		"  analytics:\n" +
+		"    provider: acme\n" +
+		"    settings:\n" +
+		"      id: UA-123\n" +
+		"      nested:\n" +
+		"        flag: enabled\n"
+	if err := os.WriteFile(ConfigFile, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := NewConfig()
+	if err != nil {
+		t.Fatalf("NewConfig() error = %v, want nil", err)
+	}
+
+	site := cfg.GetSection("site")
+	if site == nil {
+		t.Fatal(`cfg.GetSection("site") = nil, want a section`)
+	}
+	analytics := site.GetSection("analytics")
+	if analytics == nil {
+		t.Fatal(`site.GetSection("analytics") = nil, want a section (2 levels deep)`)
+	}
+	if got := analytics.GetString("provider"); got != "acme" {
+		t.Fatalf(`analytics.GetString("provider") = %q, want %q`, got, "acme")
+	}
+	settings := analytics.GetSection("settings")
+	if settings == nil {
+		t.Fatal(`analytics.GetSection("settings") = nil, want a section (3 levels deep)`)
+	}
+	if got := settings.GetString("id"); got != "UA-123" {
+		t.Fatalf(`settings.GetString("id") = %q, want %q`, got, "UA-123")
+	}
+	nested := settings.GetSection("nested")
+	if nested == nil {
+		t.Fatal(`settings.GetSection("nested") = nil, want a section (4 levels deep)`)
+	}
+	if got := nested.GetString("flag"); got != "enabled" {
+		t.Fatalf(`nested.GetString("flag") = %q, want %q`, got, "enabled")
+	}
+}


### PR DESCRIPTION
## Summary

`ConfigSection` was `map[interface{}]interface{}`, a holdover from when this package decoded YAML with `gopkg.in/yaml.v2`, which decodes a mapping into that exact type. The later migration to `go.yaml.in/yaml/v3` (which naturally decodes a mapping into `map[string]interface{}`) papered over the mismatch with a `ConfigSection.UnmarshalYAML` method plus a `normalizeConfigValue` helper, whose only job was converting every decoded `map[string]interface{}` back into the legacy `map[interface{}]interface{}` shape at every nesting level.

This PR migrates `ConfigSection` itself to `map[string]interface{}` and removes that now-unnecessary machinery entirely.

## Why the UnmarshalYAML/normalizeConfigValue machinery can simply be deleted

`go.yaml.in/yaml/v3` special-cases a named map type whose keys are strings and whose values are `interface{}`: once it decodes the outermost mapping into such a type, it keeps propagating that same named type into every nested mapping it decodes, at any depth (this is the `stringMapType` propagation in its decoder). So once `ConfigSection`'s own key type matches what YAML naturally produces, a `config.yml` with several levels of nested sections decodes into nested `ConfigSection` values all the way down, automatically, with no custom `UnmarshalYAML` method needed.

`GetSection`'s existing fallback case (for a section that arrives as a plain map rather than the named `ConfigSection` type, e.g. built by hand rather than via YAML decoding) is kept, updated from `map[interface{}]interface{}` to `map[string]interface{}`.

`GetString`/`GetSection`/`GetZString` keep their existing `string`-based signatures unchanged - this is purely an internal representation change for any caller that only goes through those methods.

`ZasData.Page`/`ZasData.Directory`'s own, separate `map[interface{}]interface{}` type (per-page YAML front matter, parsed independently of `ConfigSection` via `extractPageConfig`/`earlyPageConfig`) is untouched - out of scope for this change.

## BREAKING CHANGE

`ConfigSection`'s underlying type changes from `map[interface{}]interface{}` to `map[string]interface{}`, with **no compatibility alias**.

- Unaffected: code that only calls `GetString`/`GetSection`/`GetZString`, or builds a `ConfigSection` from a string-keyed literal (`ConfigSection{"key": value}`).
- Breaks: any code doing a direct type assertion or conversion between `ConfigSection` and `map[interface{}]interface{}` - it will no longer compile and must switch to `map[string]interface{}`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./...` (full suite green)
- [x] `TestNewConfigDoesNotAliasDefaultSections` and `TestNewConfigMergesPartialSection` re-verified: the mergo pre-seeding/aliasing behavior these protect still holds with the new map type
- [x] New `TestNewConfigNestedSections` added: exercises `GetSection` through 4 levels of nesting, not just the flat top level
- [x] `TestGetSectionRawYAMLMap` updated for the new fallback type
- [x] Repo-wide grep confirms no remaining `map[interface{}]interface{}` reference tied to `ConfigSection` (the only remaining hits belong to the separate, out-of-scope `ZasData.Page`/`Directory` type)
- [x] Live repro: built the real `zas` binary, ran `zas init`, hand-edited the generated `config.yml` to add 4 levels of nested sections under `site`, ran `zas generate` against a layout using `{{.Extra "site/analytics/settings/nested/flag"}}`-style lookups, and confirmed every level resolved correctly