### PR TITLE
Add comma-ok getters to ConfigSection and use them in Extra

### DIFF
--- a/configsection_test.go
+++ b/configsection_test.go
@@ -47,3 +47,84 @@ func TestGetSectionRawYAMLMap(t *testing.T) {
 		t.Fatalf("GetString() = %q, want %q", got, "en")
 	}
 }
+
+// GetStringOK/GetSectionOK must let a caller tell "present" apart from
+// "absent" or "wrong type" - the exact distinction GetString/GetSection
+// themselves collapse into a single zero value.
+
+func TestGetStringOKPresent(t *testing.T) {
+	cs := ConfigSection{"language": "en"}
+	got, ok := cs.GetStringOK("language")
+	if !ok {
+		t.Fatal("GetStringOK() ok = false, want true")
+	}
+	if got != "en" {
+		t.Fatalf("GetStringOK() = %q, want %q", got, "en")
+	}
+}
+
+func TestGetStringOKWrongType(t *testing.T) {
+	cs := ConfigSection{"baseurl": 123}
+	got, ok := cs.GetStringOK("baseurl")
+	if ok {
+		t.Fatal("GetStringOK() ok = true, want false for a non-string value")
+	}
+	if got != "" {
+		t.Fatalf("GetStringOK() = %q, want empty string", got)
+	}
+}
+
+func TestGetStringOKMissingKey(t *testing.T) {
+	cs := ConfigSection{}
+	got, ok := cs.GetStringOK("nope")
+	if ok {
+		t.Fatal("GetStringOK() ok = true, want false for a missing key")
+	}
+	if got != "" {
+		t.Fatalf("GetStringOK() = %q, want empty string", got)
+	}
+}
+
+func TestGetSectionOKPresent(t *testing.T) {
+	cs := ConfigSection{"site": ConfigSection{"language": "en"}}
+	section, ok := cs.GetSectionOK("site")
+	if !ok {
+		t.Fatal("GetSectionOK() ok = false, want true")
+	}
+	if got := section.GetString("language"); got != "en" {
+		t.Fatalf("GetString() = %q, want %q", got, "en")
+	}
+}
+
+func TestGetSectionOKRawYAMLMap(t *testing.T) {
+	cs := ConfigSection{"site": map[string]interface{}{"language": "en"}}
+	section, ok := cs.GetSectionOK("site")
+	if !ok {
+		t.Fatal("GetSectionOK() ok = false, want true for a raw map[string]interface{}")
+	}
+	if got := section.GetString("language"); got != "en" {
+		t.Fatalf("GetString() = %q, want %q", got, "en")
+	}
+}
+
+func TestGetSectionOKWrongType(t *testing.T) {
+	cs := ConfigSection{"site": "not-a-section"}
+	section, ok := cs.GetSectionOK("site")
+	if ok {
+		t.Fatal("GetSectionOK() ok = true, want false for a scalar value")
+	}
+	if section != nil {
+		t.Fatalf("GetSectionOK() = %v, want nil", section)
+	}
+}
+
+func TestGetSectionOKMissingKey(t *testing.T) {
+	cs := ConfigSection{}
+	section, ok := cs.GetSectionOK("nope")
+	if ok {
+		t.Fatal("GetSectionOK() ok = true, want false for a missing key")
+	}
+	if section != nil {
+		t.Fatalf("GetSectionOK() = %v, want nil", section)
+	}
+}

--- a/data.go
+++ b/data.go
@@ -107,7 +107,9 @@ func (zd *ZasData) URL() string {
 }
 
 // Extra is a helper template method to get any value from ZasData.config
-// using paths.
+// using paths. It errors both when a path segment isn't itself a section
+// and when the final key is missing or isn't a string - the two ways a
+// keypath can fail to resolve to a real value.
 func (zd *ZasData) Extra(keypath string) (value string, err error) {
 	keypath = path.Clean(keypath)
 	if path.IsAbs(keypath) {
@@ -124,7 +126,10 @@ func (zd *ZasData) Extra(keypath string) (value string, err error) {
 			return
 		}
 	}
-	value = section.GetString(key)
+	var ok bool
+	if value, ok = section.GetStringOK(key); !ok {
+		err = errors.New("not found")
+	}
 	return
 }
 

--- a/init.go
+++ b/init.go
@@ -111,24 +111,42 @@ func NewI18n(mainlang string) (i18n gt.Strings, err error) {
 	return i18n, nil
 }
 
-// GetString returns a string value from current section.
+// GetString returns a string value from current section, or "" if key is
+// missing or not a string. Callers that need to tell "absent"/"wrong type"
+// apart from a legitimately empty string should use GetStringOK instead.
 func (cs ConfigSection) GetString(key string) (value string) {
-	value, _ = cs[key].(string)
+	value, _ = cs.GetStringOK(key)
+	return
+}
+
+// GetStringOK returns a string value from current section, and whether key
+// was present and held a string value. ok is false both when key is absent
+// and when it holds a non-string value; callers that need to tell those two
+// cases apart should check key's presence themselves beforehand.
+func (cs ConfigSection) GetStringOK(key string) (value string, ok bool) {
+	value, ok = cs[key].(string)
 	return
 }
 
 // GetSection returns a subsection from current section, or nil if key is
 // missing or not a section.
 func (cs ConfigSection) GetSection(key string) (value ConfigSection) {
+	value, _ = cs.GetSectionOK(key)
+	return
+}
+
+// GetSectionOK returns a subsection from current section, and whether key
+// resolved to a real section.
+func (cs ConfigSection) GetSectionOK(key string) (value ConfigSection, ok bool) {
 	switch raw := cs[key].(type) {
 	case ConfigSection:
-		value = raw
+		value, ok = raw, true
 	case map[string]interface{}:
 		// A section built by some means other than decoding YAML into a
 		// ConfigSection-typed destination (e.g. a caller constructing one
 		// by hand as a plain map[string]interface{}) - see
 		// TestGetSectionRawYAMLMap.
-		value = ConfigSection(raw)
+		value, ok = ConfigSection(raw), true
 	}
 	return
 }

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -6,6 +6,63 @@ import (
 	"github.com/melvinmt/gt"
 )
 
+// Extra must error both when a keypath segment isn't itself a section and
+// when the final key is missing or holds a non-string value - previously
+// the final-key case silently "succeeded" with "", indistinguishable from a
+// legitimately empty string (Resolve, Extra's only production caller,
+// already discards this error deliberately - see
+// TestResolveMissingKeyFallsBackToEmpty - so this doesn't change Resolve's
+// own behavior).
+
+func TestExtraReturnsValueForPresentStringKey(t *testing.T) {
+	zd := &ZasData{
+		config: ConfigSection{"site": ConfigSection{"language": "en"}},
+	}
+	got, err := zd.Extra("/site/language")
+	if err != nil {
+		t.Fatalf("Extra() error = %v, want nil", err)
+	}
+	if got != "en" {
+		t.Fatalf("Extra() = %q, want %q", got, "en")
+	}
+}
+
+func TestExtraErrorsOnMissingFinalKey(t *testing.T) {
+	zd := &ZasData{
+		config: ConfigSection{"site": ConfigSection{}},
+	}
+	got, err := zd.Extra("/site/language")
+	if err == nil {
+		t.Fatal("Extra() with a missing final key: want error, got nil")
+	}
+	if got != "" {
+		t.Fatalf("Extra() = %q, want empty string", got)
+	}
+}
+
+func TestExtraErrorsOnWrongTypeFinalKey(t *testing.T) {
+	// e.g. a config value like "language: 5" where a string was expected.
+	zd := &ZasData{
+		config: ConfigSection{"site": ConfigSection{"language": 5}},
+	}
+	got, err := zd.Extra("/site/language")
+	if err == nil {
+		t.Fatal("Extra() with a non-string final value: want error, got nil")
+	}
+	if got != "" {
+		t.Fatalf("Extra() = %q, want empty string", got)
+	}
+}
+
+func TestExtraErrorsOnBadSectionSegment(t *testing.T) {
+	zd := &ZasData{
+		config: ConfigSection{"site": "not-a-section"},
+	}
+	if _, err := zd.Extra("/site/language"); err == nil {
+		t.Fatal("Extra() with a non-section path segment: want error, got nil")
+	}
+}
+
 // Resolve must error on a present-but-non-string value instead of
 // panicking on the `.(string)` assertion, while still falling back to ""
 // when the key is genuinely absent.


### PR DESCRIPTION
## Summary

- Add `GetStringOK`/`GetSectionOK` comma-ok variants alongside `ConfigSection`'s existing `GetString`/`GetSection`, so a caller can tell "key present" apart from "absent" or "wrong type" instead of every failure mode collapsing into the same zero value.
- `GetString`/`GetSection` now delegate to their OK counterparts; their signatures and lenient zero-value behavior are unchanged for existing call sites (many of which are template-execution paths that prefer an empty value over an error).
- Skipped a `GetZStringOK` counterpart: `GetZString` is a thin wrapper over `GetSection`+`GetString`, and a caller wanting its OK form can already compose `GetSectionOK`+`GetStringOK` directly - a dedicated wrapper would be untested, unused surface with no current consumer.
- Updated `Extra` (data.go) to use `GetStringOK` for its final key lookup, so a keypath that resolves through valid sections but lands on a missing or wrong-typed final key now returns an error - matching the error it already returns for a bad *section* segment - instead of silently succeeding with `""`. `Resolve`, `Extra`'s only production caller, already discards this error deliberately for a genuinely-absent key, so this doesn't change `Resolve`'s own behavior for any currently-passing case.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .`, `golangci-lint run ./...` all clean
- [x] `go test -race -count=1 ./...` green, including existing `configsection_test.go`, `newconfig_test.go`, `resolve_test.go`, `dirconfig_race_test.go`
- [x] New tests for `GetStringOK`/`GetSectionOK` covering present/wrong-type/absent in `configsection_test.go`
- [x] New tests for `Extra`'s changed final-key behavior in `resolve_test.go`
- [x] Built the real `zas` binary and ran `zas init` + `zas generate` against a fixture site with a normal config - unaffected
- [x] Built a fixture demonstrating the fix: a page templated with `{{.Extra "/site/author"}}` renders correctly against a valid config, then a typo'd config key (`athor` instead of `author`) now fails generation with a clear `error calling Extra: not found` instead of silently rendering an empty value