### PR TITLE
feat(zas): implement script-tag plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ zas hello World
 Hello World!
 ```
 
-That's all. Zas passes any command-line argument after subcommand name to `zshello`.
+That's all. Zas passes any command-line argument after subcommand name to `zshello`. (The same `zshello` binary is also reachable from page content - see the script tag mechanism below.)
 
 **Beware:** Zas won't pass any configuration information. Plugins are responsible for reading configuration, even from directory and page levels. Helper libraries in different languages are welcome!
 
@@ -87,15 +87,24 @@ Also, plugins are free to use `.zas` directory for their own needs. I recommend 
 +-- ...    
 ```
 
-Any `zs` plugin can be invoked through a script tag with type `application/zas+myplugin`. Arguments can be passed with data-args attribute, which content will be used as command-line invoke.
+Any `zs` plugin can also be invoked from page content through a script tag with type `application/zas+myplugin`:
 
 ```html
-<script type="application/zas+myplugin" data-args="arg1 arg2 ... argN"></script>
+<script type="application/zas+myplugin" data-args="arg1 'arg two' arg3">
+  whatever this tag's own content is
+</script>
 ```
 
-The tag is deleted after execution. Any output in stdout will replace the tag.
+The tag is deleted and replaced by whatever the plugin writes to stdout, as HTML. `data-args` supplies argv, split with shell-like quoting - `'single'` and `"double"` quotes group an argument containing spaces, and a backslash escapes the next character - but nothing here is ever handed to an actual shell, so none of `$`, `` ` ``, `*`, `~`, `#`, `|`, `;`, `&`, `<`, `>` are special; they reach the plugin literally.
 
-All plugins will be called in order. Oh, you can even ask for async execution with same-name attribute (hint: async).
+Unlike an `<embed>`, this tag's own inner content isn't parsed as HTML at all: `<script>` is one of the few HTML elements whose content is raw text, so whatever you write between the tags - a JSON object, a CSV table, a block of YAML, anything - survives byte for byte and is piped to the plugin's stdin exactly as written, entities and all. That's the point of reaching for a script tag instead of `embed`/`mzs*`: it lets you write inline data a plugin turns into HTML, rather than only ever pointing at a separate file.
+
+A few things to know:
+
+- **No `async` yet.** Every zas script tag runs synchronously, in document order, one at a time. The tag accepts an `async` attribute, but it's currently ignored.
+- **Placement matters.** In a page's own content, the tag must resolve somewhere in the eventual `<body>` - a leading config comment does *not* stop the parser from placing a script written as the very first thing in a file into `<head>` instead, and Zas will refuse to guess what you meant, failing the build with a clear error instead. Inside `layout.html` specifically, a tag in `<head>` is allowed, but only for output that's actually valid there (`<meta>`, `<link>`, `<base>`, `<style>`, `<title>`) - handy for a plugin that injects per-build metadata into every page's head. Anything else placed in `layout.html`'s `<head>` also fails the build rather than silently vanishing.
+- **Not re-scanned.** A plugin's own output isn't searched for further zas script tags in the same pass - except that a page-body tag's output does get one more look, since the whole assembled page is parsed again to merge it with the layout (see below). A tag written directly into `layout.html` gets no such second pass.
+- Only tags whose `type` starts with `application/zas+` are ever touched. Ordinary JavaScript, `application/ld+json`, or any other `<script>` - anywhere, including inside `layout.html` - is left completely alone.
 
 #### What's the deal with "mzs" prefix? (a.k.a. MIME types plugins)
 
@@ -119,12 +128,15 @@ If you develop a new plugin, please contact me, and I will list it here :) Pleas
 
 #### Plugin trust model
 
-Both plugin mechanisms resolve a name to a binary on `PATH` and execute it - Zas does no sandboxing, signing, or verification of what it finds there. That's a deliberate design, in the same spirit as how `git <subcommand>` resolves to `git-<subcommand>` on `PATH`, but it's worth being explicit about the two different ways a plugin name gets chosen:
+All plugin mechanisms resolve a name to a binary on `PATH` and execute it - Zas does no sandboxing, signing, or verification of what it finds there. That's a deliberate design, in the same spirit as how `git <subcommand>` resolves to `git-<subcommand>` on `PATH`, but it's worth being explicit about the three different ways a plugin name gets chosen, since they carry different levels of trust:
 
-- **`zas <name>` subcommand plugins** are only ever invoked from a name you (or a script you wrote) typed directly as a command-line argument - the same trust level as running any other program by name in your shell.
+- **`zas <name>` subcommands** are only ever invoked from a name you (or a script you wrote) typed directly as a command-line argument - the same trust level as running any other program by name in your shell.
 - **`mzs*` MIME type plugins** are chosen by `mimetypes:` config and triggered by `<embed type="...">` tags found in site *content*. If you ever run `zas generate` over content you don't fully control - a preview build from an external contribution, for example - that content effectively gets to pick which already-installed plugin binary runs, with the embed's `src` as an argument.
+- **`zs*` script-tag plugins** go further still: a `<script type="application/zas+name">` tag in page content picks the exact same `zs<name>` binary the command line would, *and* supplies both its arguments (`data-args`) and its stdin (the tag's own content). Note this means the `zs<name>` binaries themselves are no longer reachable only from something you typed yourself - content can name one directly.
 
-If that second case applies to you, pass `-no-plugins` to `zas generate`: any embed that would need an external MIME type plugin fails with a clear error instead of executing anything (Zas's own built-in embed handlers, like Markdown, aren't affected - they never spawn a process).
+Every plugin name - from `mimetypes:` config or from a script tag's `type` - is validated as a plain `[a-zA-Z0-9_-]+` string before anything is executed, so content can't smuggle in a path (`../../something`) to make `exec.Command` skip `PATH` lookup entirely.
+
+If you run `zas generate` over content you don't fully control, pass `-no-plugins`: any embed needing an external MIME type plugin, or any script tag naming one, fails with a clear error instead of executing anything. This does not cover the `zas <name>` command line itself, which is never content-triggered. Zas's own built-in embed handlers (like `Markdown`) aren't affected either - they never spawn a process.
 
 ## Building sites
 

--- a/cmd/zas/main.go
+++ b/cmd/zas/main.go
@@ -63,7 +63,7 @@ var (
 func init() {
 	verbose = cmdGenerate.Flag.Bool("verbose", false, "Verbose output")
 	full = cmdGenerate.Flag.Bool("full", false, "Full generation (non-incremental mode)")
-	noPlugins = cmdGenerate.Flag.Bool("no-plugins", false, "Disable content-triggered MIME-type plugin execution (see README's \"Plugins\" section)")
+	noPlugins = cmdGenerate.Flag.Bool("no-plugins", false, "Disable content-triggered plugin execution: <embed> MIME-type plugins and application/zas+ script tags (see README's \"Plugins\" section)")
 
 	cmdHelp.Run = func() error {
 		printUsage(os.Stdout)

--- a/generate.go
+++ b/generate.go
@@ -132,16 +132,19 @@ type Generator struct {
 	Verbose bool
 	// Full generation (non-incremental mode).
 	Full bool
-	// NoPlugins disables content-triggered MIME-type plugin execution (see
-	// handleMIMETypePlugin): an embed that resolves to an external plugin
-	// fails with a clear per-page error instead of exec'ing anything. It
-	// has no effect on zas's own internal embed handlers (Markdown, Plain,
-	// Html), which never spawn a process, or on the separate zs<name>
-	// subcommand-plugin mechanism cmd/zas dispatches directly from argv -
-	// that path only ever fires from a name the invoking user typed
-	// themselves, not from site content. Set this when generating from
-	// content you don't fully control (see README's "Plugins" section for
-	// the full trust model this guards).
+	// NoPlugins disables every content-triggered plugin execution: an
+	// <embed> resolving to an external MIME-type plugin
+	// (handleMIMETypePlugin) and a <script type="application/zas+name">
+	// tag that would exec zs<name> (handleScriptPlugin) each fail with a
+	// clear per-page error instead of exec'ing anything. It has no effect
+	// on zas's own internal embed handlers (Markdown, Plain, Html), which
+	// never spawn a process, or on the argv dispatch in cmd/zas, which is
+	// chosen by a name the invoking user typed. Note the zs<name> binaries
+	// themselves are no longer argv-only reachable - script-tag plugins let
+	// page content name one directly, which is exactly what this flag
+	// shuts off. Set this when generating from content you don't fully
+	// control (see README's "Plugins" section for the full trust model
+	// this guards).
 	NoPlugins bool
 	// Config holds the site configuration. Run always overwrites it with
 	// the freshly loaded contents of ConfigFile, so setting it before
@@ -370,20 +373,23 @@ func (gen *Generator) Generate(_ string, data *ZasData) (err error) {
 	// This parseAndReplace is a second full HTML5 parse of the page - render
 	// already ran one over the page's own source to produce data.Body. It's
 	// not redundant: render's parse only ever sees the page's own markup, so
-	// an <embed> written directly into layout.html itself (outside
-	// {{.Body}}, e.g. a site-wide footer) is invisible to it and can only
-	// resolve here, against the fully assembled layout+body page (see
-	// TestGenerateResolvesEmbedInLayoutItself). html/template also has no
-	// notion of a parsed tree to merge the two passes' output into - it
-	// only ever produces bytes - so there's no cheaper way to give this
-	// pass's embed handling a shot at the assembled page than re-parsing
-	// it whole. Re-serializing through html5.Render below is also why
-	// deployed output isn't guaranteed byte-identical to what either the
-	// page or the layout wrote: HTML5's parser normalizes as it goes
-	// (attribute quoting, tag casing, void-element closing, entity
+	// an <embed> or a <script type="application/zas+..."> plugin tag
+	// written directly into layout.html itself (outside {{.Body}}, e.g. a
+	// site-wide footer, or a <meta> generator in <head>) is invisible to it
+	// and can only resolve here, against the fully assembled layout+body
+	// page (see TestGenerateResolvesEmbedInLayoutItself). html/template
+	// also has no notion of a parsed tree to merge the two passes' output
+	// into - it only ever produces bytes - so there's no cheaper way to
+	// give this pass's embed/script handling a shot at the assembled page
+	// than re-parsing it whole. Re-serializing through html5.Render below
+	// is also why deployed output isn't guaranteed byte-identical to what
+	// either the page or the layout wrote: HTML5's parser normalizes as it
+	// goes (attribute quoting, tag casing, void-element closing, entity
 	// escaping), so this isn't a candidate for a stricter, non-repairing
-	// parse.
-	doc, err := gen.parseAndReplace(&processed, data)
+	// parse. headRendered (see headFate) reflects that this pass, unlike
+	// every other parseAndReplace call, produces the document whose <head>
+	// actually reaches deployed output.
+	doc, err := gen.parseAndReplace(&processed, data, headRendered)
 	if err != nil {
 		return
 	}
@@ -411,7 +417,24 @@ func (gen *Generator) Generate(_ string, data *ZasData) (err error) {
 // goroutine's stack is exhausted.
 const maxEmbedDepth = 20
 
-func (gen *Generator) parseAndReplace(processed io.Reader, data *ZasData) (doc *goquery.Document, err error) {
+// headFate says whether the <head> of the document being parsed survives
+// into deployed output. Only Generate's pass renders a whole assembled
+// page; render's own pass, and every embed handler, only ever keeps a
+// document's body (see data.Body in render, and the .Contents() splices in
+// Markdown/Html) - so a script-tag plugin's output placed in <head> there
+// is discarded regardless of what it is, while Generate's own pass can
+// actually deliver head-eligible output (<meta>, <link>, ...) to the
+// deployed page. handleScriptTags uses this to decide whether <head>
+// placement is refused outright or merely required to produce something
+// that HTML5 will actually let live there - see handleScriptPlugin.
+type headFate bool
+
+const (
+	headDropped  headFate = false
+	headRendered headFate = true
+)
+
+func (gen *Generator) parseAndReplace(processed io.Reader, data *ZasData, head headFate) (doc *goquery.Document, err error) {
 	if data.embedDepth >= maxEmbedDepth {
 		return nil, fmt.Errorf("embed nesting deeper than %d levels; check for a self- or mutually-embedding file", maxEmbedDepth)
 	}
@@ -420,6 +443,9 @@ func (gen *Generator) parseAndReplace(processed io.Reader, data *ZasData) (doc *
 	// Here we manipulate its result.
 	doc, err = goquery.NewDocumentFromReader(processed)
 	if err != nil {
+		return
+	}
+	if err = gen.handleScriptTags(doc, head); err != nil {
 		return
 	}
 	err = gen.handleEmbedTags(doc, data)
@@ -1172,7 +1198,7 @@ func (gen *Generator) render(path string, input []byte) (err error) {
 			return
 		}
 	}
-	doc, err := gen.parseAndReplace(&processed, &data)
+	doc, err := gen.parseAndReplace(&processed, &data, headDropped)
 	if err != nil {
 		return
 	}
@@ -1368,7 +1394,7 @@ func (gen *Generator) Markdown(e *goquery.Selection, _ *goquery.Document, data *
 		if err := markdownConverter.Convert(mdInput, &b); err != nil {
 			return err
 		}
-		mdDoc, err := gen.parseAndReplace(&b, data)
+		mdDoc, err := gen.parseAndReplace(&b, data, headDropped)
 		if err != nil {
 			return err
 		}
@@ -1424,7 +1450,7 @@ func (gen *Generator) Html(e *goquery.Selection, _ *goquery.Document, data *ZasD
 			return err
 		}
 		var htmlDoc *goquery.Document
-		htmlDoc, err = gen.parseAndReplace(bytes.NewBuffer(input), data)
+		htmlDoc, err = gen.parseAndReplace(bytes.NewBuffer(input), data, headDropped)
 		if err != nil {
 			return err
 		}

--- a/harness_test.go
+++ b/harness_test.go
@@ -49,6 +49,10 @@ func fullGen(g *Generator) {
 	g.Full = true
 }
 
+func noPluginsGen(g *Generator) {
+	g.NoPlugins = true
+}
+
 func readDeploy(t *testing.T, rel string) string {
 	t.Helper()
 	data, err := os.ReadFile(filepath.Join(".zas", "deploy", rel))

--- a/script_plugin_e2e_test.go
+++ b/script_plugin_e2e_test.go
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2013 Dario Castañé.
+ * This file is part of Zas.
+ *
+ * Zas is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Zas is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Zas.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package zas
+
+import (
+	"strings"
+	"testing"
+)
+
+// zsEchoStub wraps its argv (joined, --tag <name> selects the wrapping
+// element) around a literal string, e.g. --tag b 'hello world' -> "<b>hello
+// world</b>". zsWrapStub wraps its raw stdin in <pre>...</pre> - the
+// generic "prove the plugin actually ran on real input" shape used across
+// these tests. Installed per test via installStub (script_plugin_test.go).
+const zsEchoStub = `#!/bin/sh
+tag=span
+text=
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --tag) tag="$2"; shift 2 ;;
+    *) text="$1"; shift ;;
+  esac
+done
+printf '<%s>%s</%s>' "$tag" "$text" "$tag"
+`
+
+const zsWrapStub = "#!/bin/sh\nprintf '<pre>'; cat; printf '</pre>'\n"
+
+func TestGenerateRunsScriptPluginInPageBody(t *testing.T) {
+	installStub(t, "zsecho", zsEchoStub)
+	installStub(t, "zswrap", zsWrapStub)
+	newTestSite(t, "script-plugin-site")
+	if err := generate(t); err != nil {
+		t.Fatalf("generate() error = %v, want nil", err)
+	}
+	got := readDeploy(t, "index.html")
+	if !strings.Contains(got, "<b>hello world</b>") {
+		t.Fatalf("deployed index.html = %q, want the zsecho plugin's output", got)
+	}
+	if !strings.Contains(got, `<pre>{&#34;k&#34;: &#34;v&#34;}</pre>`) {
+		t.Fatalf("deployed index.html = %q, want the zswrap plugin's output with its stdin intact", got)
+	}
+	if strings.Contains(got, "application/zas+") {
+		t.Fatalf("deployed index.html = %q, want no zas script tag left behind", got)
+	}
+	if !strings.Contains(got, `var pageJS = "a<b";`) {
+		t.Fatalf("deployed index.html = %q, want the page's real <script> untouched", got)
+	}
+	if !strings.Contains(got, `"@context": "https://schema.org"`) {
+		t.Fatalf("deployed index.html = %q, want the layout's JSON-LD script untouched", got)
+	}
+}
+
+func TestGenerateScriptPluginOutputSplicesWithoutNesting(t *testing.T) {
+	installStub(t, "zsecho", "#!/bin/sh\necho '<html><head><title>t</title></head><body><p>x</p></body></html>'\n")
+	installStub(t, "zswrap", zsWrapStub)
+	newTestSite(t, "script-plugin-site")
+	if err := generate(t); err != nil {
+		t.Fatalf("generate() error = %v, want nil", err)
+	}
+	got := readDeploy(t, "index.html")
+	for _, tag := range []string{"<html", "<head", "<body"} {
+		if n := strings.Count(got, tag); n != 1 {
+			t.Fatalf("deployed index.html = %q, want exactly one %q (the outer page's own), got %d", got, tag, n)
+		}
+	}
+	if !strings.Contains(got, "<p>x</p>") {
+		t.Fatalf("deployed index.html = %q, want the plugin's own body content spliced in", got)
+	}
+}
+
+func TestGenerateRunsScriptPluginInLayoutBody(t *testing.T) {
+	installStub(t, "zsecho", zsEchoStub)
+	installStub(t, "zsmeta", "#!/bin/sh\necho '<meta name=\"generated\" content=\"x\">'\n")
+	newTestSite(t, "script-plugin-layout-site")
+	if err := generate(t); err != nil {
+		t.Fatalf("generate() error = %v, want nil", err)
+	}
+	got := readDeploy(t, "index.html")
+	if !strings.Contains(got, "from the layout itself") {
+		t.Fatalf("deployed index.html = %q, want the layout body's own script plugin output", got)
+	}
+	if strings.Contains(got, "application/zas+") {
+		t.Fatalf("deployed index.html = %q, want no zas script tag left in the layout", got)
+	}
+}
+
+func TestGenerateRunsScriptPluginInLayoutHead(t *testing.T) {
+	installStub(t, "zsecho", zsEchoStub)
+	installStub(t, "zsmeta", "#!/bin/sh\necho '<meta name=\"generated\" content=\"x\">'\n")
+	newTestSite(t, "script-plugin-layout-site")
+	if err := generate(t); err != nil {
+		t.Fatalf("generate() error = %v, want nil", err)
+	}
+	got := readDeploy(t, "index.html")
+	if !strings.Contains(got, `<meta name="generated" content="x"/>`) {
+		t.Fatalf("deployed index.html = %q, want the layout head's script plugin output to have reached deployed output", got)
+	}
+}
+
+func TestGenerateFailsOnHeadPlacedScriptInPage(t *testing.T) {
+	newTestSite(t, "script-plugin-head-site")
+	err := generate(t)
+	if err == nil {
+		t.Fatal("generate() for a page-opening zas script tag: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "<head>") {
+		t.Fatalf("generate() error = %v, want it to mention <head>", err)
+	}
+	assertDeployMissing(t, "index.html")
+}
+
+func TestGenerateNoPluginsRefusesScriptPlugin(t *testing.T) {
+	installStub(t, "zsecho", zsEchoStub)
+	installStub(t, "zswrap", zsWrapStub)
+	newTestSite(t, "script-plugin-site")
+	err := generate(t, noPluginsGen)
+	if err == nil {
+		t.Fatal("generate() with NoPlugins set: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "-no-plugins") {
+		t.Fatalf("generate() error = %v, want it to mention -no-plugins", err)
+	}
+	assertDeployMissing(t, "index.html")
+}
+
+func TestGenerateScriptPluginOutputEmbedResolves(t *testing.T) {
+	installStub(t, "zsecho", zsEchoStub)
+	installStub(t, "zswrap", "#!/bin/sh\necho '<embed src=\"partials/nav.html\" type=\"text/html\">'\n")
+	newTestSite(t, "script-plugin-site")
+	if err := generate(t); err != nil {
+		t.Fatalf("generate() error = %v, want nil", err)
+	}
+	got := readDeploy(t, "index.html")
+	if !strings.Contains(got, "nav from a plugin-emitted embed") {
+		t.Fatalf("deployed index.html = %q, want the plugin-emitted <embed> to have resolved", got)
+	}
+	if strings.Contains(got, "<embed") {
+		t.Fatalf("deployed index.html = %q, want no <embed> tag left unresolved", got)
+	}
+}
+
+func TestGenerateDoesNotRunScriptPluginInFencedCodeBlock(t *testing.T) {
+	// No plugin is installed at all - PATH is left as the test's own,
+	// which won't have a zsecho binary either. If the scanner ever
+	// mistakenly reached into the fenced code block, this would fail with
+	// a missing-binary error instead of succeeding.
+	newTestSite(t, "script-plugin-codeblock-site")
+	if err := generate(t); err != nil {
+		t.Fatalf("generate() error = %v, want nil (a fenced code block must never execute)", err)
+	}
+	got := readDeploy(t, "codeblock.html")
+	if !strings.Contains(got, `&lt;script type=&#34;application/zas+echo&#34;&gt;`) {
+		t.Fatalf("deployed codeblock.html = %q, want the script tag to still be escaped, unexecuted text", got)
+	}
+}
+
+func TestGenerateRunsScriptPluginInMarkdownPage(t *testing.T) {
+	installStub(t, "zswrap", zsWrapStub)
+	newTestSite(t, "script-plugin-markdown-site")
+	if err := generate(t); err != nil {
+		t.Fatalf("generate() error = %v, want nil", err)
+	}
+	got := readDeploy(t, "data.html")
+	if !strings.Contains(got, "name,count") || !strings.Contains(got, "a,1") || !strings.Contains(got, "b,2") {
+		t.Fatalf("deployed data.html = %q, want the multi-line inline data block piped to the plugin", got)
+	}
+}

--- a/script_plugin_test.go
+++ b/script_plugin_test.go
@@ -1,0 +1,349 @@
+/*
+ * Copyright (c) 2013 Dario Castañé.
+ * This file is part of Zas.
+ *
+ * Zas is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Zas is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Zas.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package zas
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+// installStub writes an executable shell-script plugin stub named name
+// into a fresh directory and prepends it to PATH - unlike
+// mime_plugin_test.go's stubs, several of these scripts shell out to real
+// utilities (cat) to read stdin, so the original PATH must stay reachable.
+func installStub(t *testing.T, name, script string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script plugin stub is not portable to windows")
+	}
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, name), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func mustParseDoc(t *testing.T, htmlStr string) *goquery.Document {
+	t.Helper()
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(htmlStr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return doc
+}
+
+func TestSplitArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"all whitespace", "   ", nil},
+		{"simple fields", "a b  c", []string{"a", "b", "c"}},
+		{"single quoted with space", `--title 'My Post'`, []string{"--title", "My Post"}},
+		{"double quoted with space", `--title "My Post"`, []string{"--title", "My Post"}},
+		{"empty single quotes", "''", []string{""}},
+		{"empty double quotes", `""`, []string{""}},
+		{"quote removal mid-field", `a''b`, []string{"ab"}},
+		{"mixed quote removal", `-x'y'"z"`, []string{"-xyz"}},
+		{"single quotes keep backslash literal", `'a\b'`, []string{`a\b`}},
+		{"double quotes escape quote", `"a\"b"`, []string{`a"b`}},
+		{"double quotes escape backslash", `"a\\b"`, []string{`a\b`}},
+		{"double quotes keep other escapes literal", "\"a\\nb\"", []string{`a\nb`}},
+		{"backslash escapes space", `a\ b`, []string{"a b"}},
+		{"backslash escapes quote outside quotes", `a\'b`, []string{"a'b"}},
+		{"shell metacharacters are literal", `a\|b;c&d`, []string{"a|b;c&d"}},
+		{"utf8 argument", "café", []string{"café"}},
+		{"glob is literal", "*.md", []string{"*.md"}},
+		{"hash is literal", "#x", []string{"#x"}},
+		{"newline separates fields", "a\nb", []string{"a", "b"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := splitArgs(tt.in)
+			if err != nil {
+				t.Fatalf("splitArgs(%q) error = %v, want nil", tt.in, err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("splitArgs(%q) = %#v, want %#v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSplitArgsRejectsUnbalancedQuoting(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{"unterminated single quote", `'x`},
+		{"unterminated double quote", `"x`},
+		{"trailing backslash", `x\`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args, err := splitArgs(tt.in)
+			if err == nil {
+				t.Fatalf("splitArgs(%q) error = nil, want an error", tt.in)
+			}
+			if args != nil {
+				t.Fatalf("splitArgs(%q) args = %#v, want nil", tt.in, args)
+			}
+		})
+	}
+}
+
+func TestHandleScriptTagsRunsExternalCommand(t *testing.T) {
+	installStub(t, "zstest", "#!/bin/sh\necho '<b>ok</b>'\n")
+	doc := mustParseDoc(t, `<html><body><script type="application/zas+test"></script></body></html>`)
+	gen := &Generator{}
+	if err := gen.handleScriptTags(doc, headDropped); err != nil {
+		t.Fatalf("handleScriptTags() error = %v, want nil", err)
+	}
+	if got := doc.Find("b").Text(); got != "ok" {
+		t.Fatalf("plugin output not spliced into the document: got %q", got)
+	}
+	if doc.Find("script[type='application/zas+test']").Length() != 0 {
+		t.Fatal("zas script tag still present after handleScriptTags()")
+	}
+}
+
+func TestHandleScriptTagsPipesInnerContentToStdin(t *testing.T) {
+	installStub(t, "zswrap", "#!/bin/sh\nprintf '<pre>'; cat; printf '</pre>'\n")
+	doc := mustParseDoc(t, `<html><body><script type="application/zas+wrap">{"k":"v"}</script></body></html>`)
+	gen := &Generator{}
+	if err := gen.handleScriptTags(doc, headDropped); err != nil {
+		t.Fatalf("handleScriptTags() error = %v, want nil", err)
+	}
+	if got := strings.TrimSpace(doc.Find("pre").Text()); got != `{"k":"v"}` {
+		t.Fatalf("stdin not piped through: got %q", got)
+	}
+}
+
+func TestHandleScriptTagsStdinIsNotEntityDecoded(t *testing.T) {
+	// The point of this test: if the tokenizer entity-decoded <script>
+	// content the way it does for ordinary text nodes, "&amp;lt;" would
+	// reach the plugin as "<" instead of the literal six characters an
+	// author wrote - defeating the whole premise of piping raw data
+	// through a zas script tag.
+	installStub(t, "zscheck", `#!/bin/sh
+if [ "$(cat)" = '&amp;lt;' ]; then
+  echo '<b>raw</b>'
+else
+  echo '<b>decoded</b>'
+fi
+`)
+	doc := mustParseDoc(t, `<html><body><script type="application/zas+check">&amp;lt;</script></body></html>`)
+	gen := &Generator{}
+	if err := gen.handleScriptTags(doc, headDropped); err != nil {
+		t.Fatalf("handleScriptTags() error = %v, want nil", err)
+	}
+	if got := doc.Find("b").Text(); got != "raw" {
+		t.Fatalf("stdin content = %q outcome, want the raw (undecoded) bytes to reach the plugin", got)
+	}
+}
+
+func TestHandleScriptTagsPassesDataArgs(t *testing.T) {
+	installStub(t, "zstest", `#!/bin/sh
+for a in "$@"; do printf '<li>%s</li>' "$a"; done
+`)
+	doc := mustParseDoc(t, `<html><body><script type="application/zas+test" data-args="--title 'My Post' plain"></script></body></html>`)
+	gen := &Generator{}
+	if err := gen.handleScriptTags(doc, headDropped); err != nil {
+		t.Fatalf("handleScriptTags() error = %v, want nil", err)
+	}
+	var got []string
+	doc.Find("li").Each(func(_ int, s *goquery.Selection) {
+		got = append(got, s.Text())
+	})
+	want := []string{"--title", "My Post", "plain"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args spliced = %#v, want %#v", got, want)
+	}
+}
+
+func TestHandleScriptTagsLeavesNonZasScriptsUntouched(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	src := `<html><head></head><body>` +
+		`<script>var x = 1;</script>` +
+		`<script type="text/javascript">var y = 2;</script>` +
+		`<script type="application/ld+json">{"a":1}</script>` +
+		`</body></html>`
+	doc := mustParseDoc(t, src)
+	before := doc.Find("script").Length()
+	gen := &Generator{}
+	if err := gen.handleScriptTags(doc, headDropped); err != nil {
+		t.Fatalf("handleScriptTags() error = %v, want nil", err)
+	}
+	if got := doc.Find("script").Length(); got != before {
+		t.Fatalf("script count = %d after handleScriptTags(), want unchanged %d", got, before)
+	}
+}
+
+func TestHandleScriptTagsRejectsPathSeparatorInType(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	doc := mustParseDoc(t, `<html><body><script type="application/zas+../../evil"></script></body></html>`)
+	gen := &Generator{}
+	err := gen.handleScriptTags(doc, headDropped)
+	if err == nil {
+		t.Fatal("handleScriptTags() with a path-separator plugin name: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no valid plugin") {
+		t.Fatalf("error = %v, want the name rejected before exec", err)
+	}
+	if doc.Find("script").Length() != 1 {
+		t.Fatal("script tag was removed despite the name being rejected")
+	}
+}
+
+func TestHandleScriptTagsNoPluginsRefusesToExec(t *testing.T) {
+	installStub(t, "zstest", "#!/bin/sh\necho '<b>ok</b>'\n")
+	doc := mustParseDoc(t, `<html><body><script type="application/zas+test"></script></body></html>`)
+	gen := &Generator{NoPlugins: true}
+	err := gen.handleScriptTags(doc, headDropped)
+	if err == nil {
+		t.Fatal("handleScriptTags() with NoPlugins set: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "-no-plugins") {
+		t.Fatalf("error = %v, want it to mention -no-plugins", err)
+	}
+	if !strings.Contains(err.Error(), "zstest") {
+		t.Fatalf("error = %v, want it to name the plugin binary", err)
+	}
+	if doc.Find("script[type='application/zas+test']").Length() != 1 {
+		t.Fatal("script tag was replaced despite NoPlugins - plugin executed anyway")
+	}
+}
+
+func TestHandleScriptTagsRefusesHeadPlacementInPagePass(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	// A leading HTML comment (the shape of a page's own config comment)
+	// does not force body insertion mode, so a script tag right after it
+	// is still parsed into <head> - proving the constraint this test
+	// exercises is real, not hypothetical.
+	doc := mustParseDoc(t, `<!-- title: x --><script type="application/zas+test"></script><p>b</p>`)
+	if doc.Find("head script").Length() != 1 {
+		t.Fatal("test fixture invalid: expected the script to be parsed into <head>")
+	}
+	gen := &Generator{}
+	err := gen.handleScriptTags(doc, headDropped)
+	if err == nil {
+		t.Fatal("handleScriptTags() for a head-placed script in the page pass: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "<head>") {
+		t.Fatalf("error = %v, want it to mention <head>", err)
+	}
+	if doc.Find("script[type='application/zas+test']").Length() != 1 {
+		t.Fatal("script tag was removed despite being refused")
+	}
+}
+
+func TestHandleScriptTagsAllowsHeadEligibleOutputInLayoutPass(t *testing.T) {
+	installStub(t, "zsmeta", "#!/bin/sh\necho '<meta name=\"generated\" content=\"x\">'\n")
+	doc := mustParseDoc(t, `<html><head><script type="application/zas+meta"></script></head><body></body></html>`)
+	gen := &Generator{}
+	if err := gen.handleScriptTags(doc, headRendered); err != nil {
+		t.Fatalf("handleScriptTags() error = %v, want nil", err)
+	}
+	if doc.Find(`head meta[name="generated"]`).Length() != 1 {
+		t.Fatal("head-eligible plugin output did not land in <head>")
+	}
+}
+
+func TestHandleScriptTagsRejectsNonEligibleHeadOutputInLayoutPass(t *testing.T) {
+	installStub(t, "zsbad", "#!/bin/sh\necho '<b>ok</b>'\n")
+	doc := mustParseDoc(t, `<html><head><script type="application/zas+bad"></script></head><body></body></html>`)
+	gen := &Generator{}
+	err := gen.handleScriptTags(doc, headRendered)
+	if err == nil {
+		t.Fatal("handleScriptTags() for non-head-eligible output in <head>: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot be placed") {
+		t.Fatalf("error = %v, want it to explain the output cannot be placed", err)
+	}
+}
+
+func TestHandleScriptTagsMissingBinaryReturnsError(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	doc := mustParseDoc(t, `<html><body><script type="application/zas+doesnotexist"></script></body></html>`)
+	gen := &Generator{}
+	if err := gen.handleScriptTags(doc, headDropped); err == nil {
+		t.Fatal("handleScriptTags() with no matching binary on PATH: want error, got nil")
+	}
+}
+
+func TestHandleScriptTagsInvalidDataArgsReturnsError(t *testing.T) {
+	installStub(t, "zstest", "#!/bin/sh\necho '<b>ok</b>'\n")
+	doc := mustParseDoc(t, `<html><body><script type="application/zas+test" data-args="--title 'oops"></script></body></html>`)
+	gen := &Generator{}
+	err := gen.handleScriptTags(doc, headDropped)
+	if err == nil {
+		t.Fatal("handleScriptTags() with invalid data-args: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "data-args") {
+		t.Fatalf("error = %v, want it to mention data-args", err)
+	}
+	if doc.Find("script[type='application/zas+test']").Length() != 1 {
+		t.Fatal("script tag was removed despite invalid data-args (plugin must not have run)")
+	}
+}
+
+func TestHandleScriptTagsPluginIgnoringStdinSucceeds(t *testing.T) {
+	installStub(t, "zstest", "#!/bin/sh\necho '<b>ok</b>'\n")
+	inner := strings.Repeat("x", 1<<20)
+	doc := mustParseDoc(t, `<html><body><script type="application/zas+test">`+inner+`</script></body></html>`)
+	gen := &Generator{}
+	if err := gen.handleScriptTags(doc, headDropped); err != nil {
+		t.Fatalf("handleScriptTags() error = %v, want nil (plugin ignoring stdin must not fail the build)", err)
+	}
+}
+
+func TestHandleScriptTagsFirstErrorAbortsRemainingTags(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	doc := mustParseDoc(t, `<html><body>`+
+		`<script type="application/zas+first"></script>`+
+		`<script type="application/zas+second"></script>`+
+		`</body></html>`)
+	gen := &Generator{}
+	if err := gen.handleScriptTags(doc, headDropped); err == nil {
+		t.Fatal("handleScriptTags() error = nil, want an error from the first missing binary")
+	}
+	if doc.Find("script[type='application/zas+second']").Length() != 1 {
+		t.Fatal("second script tag was processed despite the first one erroring")
+	}
+}
+
+func TestHandleScriptTagsMatchesTypeCaseInsensitively(t *testing.T) {
+	installStub(t, "zstest", "#!/bin/sh\necho '<b>ok</b>'\n")
+	doc := mustParseDoc(t, `<html><body><script type="APPLICATION/ZAS+Test"></script></body></html>`)
+	gen := &Generator{}
+	if err := gen.handleScriptTags(doc, headDropped); err != nil {
+		t.Fatalf("handleScriptTags() error = %v, want nil", err)
+	}
+	if got := doc.Find("b").Text(); got != "ok" {
+		t.Fatalf("plugin output not spliced into the document: got %q", got)
+	}
+}

--- a/scriptplugin.go
+++ b/scriptplugin.go
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2013 Dario Castañé.
+ * This file is part of Zas.
+ *
+ * Zas is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Zas is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Zas.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package zas
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	html5 "golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
+)
+
+// scriptPluginType is the <script type="..."> value prefix that marks a
+// tag as a build-time plugin invocation: everything after it is the
+// plugin name, so type="application/zas+myplugin" runs zsmyplugin.
+const scriptPluginType = "application/" + Name + "+"
+
+// dataArgsAttr holds a zas script tag's command-line arguments. It has no
+// html/atom entry - atom only covers standard attribute names - so unlike
+// type/src it's spelled out as a literal rather than taken from atom.
+const dataArgsAttr = "data-args"
+
+/*
+ * Handles <script type="application/zas+name"> tags by running the
+ * zs<name> plugin (see handleScriptPlugin).
+ *
+ * Every other <script> - real JavaScript, application/ld+json, a bare
+ * <script> with no type at all - is left completely alone: not rewritten,
+ * not reparsed, not even touched. A <script> typed inside a fenced code
+ * block never reaches here either; goldmark escapes it, so it's a text
+ * node, not an element, and Find never sees it (see codeblock_test.go).
+ *
+ * doc.Find returns a snapshot of the matching nodes, so anything this
+ * splices in is never visited by this loop - a plugin cannot recursively
+ * trigger itself, and no depth guard is needed (unlike Markdown/Html,
+ * which recurse through parseAndReplace and are bounded by
+ * maxEmbedDepth). One exception worth knowing: a script tag in a page's
+ * own body fires during render's pass, and its output is then re-parsed
+ * by Generate's own pass - so output containing another zas script tag
+ * runs once more there. A layout-level tag gets no such second chance.
+ */
+func (gen *Generator) handleScriptTags(doc *goquery.Document, head headFate) (err error) {
+	doc.Find(atom.Script.String()).EachWithBreak(func(_ int, e *goquery.Selection) bool {
+		typ, ok := e.Attr(atom.Type.String())
+		if !ok {
+			return true
+		}
+		name, ok := strings.CutPrefix(strings.ToLower(strings.TrimSpace(typ)), scriptPluginType)
+		if !ok {
+			return true
+		}
+		err = gen.handleScriptPlugin(e, typ, name, head)
+		return err == nil
+	})
+	return
+}
+
+/*
+ * Invokes a zs<name> plugin named by a script tag's type attribute. The
+ * tag's data-args attribute supplies argv (see splitArgs), its raw inner
+ * text is piped to the plugin's stdin, and its stdout replaces the whole
+ * tag as HTML; stderr is passed through to the user's shell.
+ *
+ * <script> is an HTML5 raw-text element, so the tokenizer never entity-
+ * decodes its content: an inline JSON/CSV/DOT/YAML data block reaches the
+ * plugin byte for byte, which is the whole point of hanging this on
+ * <script> rather than on another, parsed element - that's a deliberate
+ * extension beyond a script tag's literal, argument-only README spec.
+ *
+ * async is deliberately not supported: every tag runs synchronously, in
+ * document order. It's accepted as an attribute and simply ignored - a
+ * second fan-out layer inside already-concurrent page rendering is
+ * exactly where this codebase has had its race and goroutine-leak bugs
+ * (see the C1-C6 audit history).
+ */
+func (gen *Generator) handleScriptPlugin(e *goquery.Selection, typ, name string, head headFate) error {
+	if !pluginNameRe.MatchString(name) {
+		return fmt.Errorf("no valid plugin named by script type %q", typ)
+	}
+	if gen.NoPlugins {
+		return fmt.Errorf("plugin execution disabled (-no-plugins): script type %q needs plugin %s%s", typ, PluginPrefix, name)
+	}
+	inHead := e.Closest(atom.Head.String()).Length() > 0
+	if inHead && head == headDropped {
+		return fmt.Errorf("script type %q was parsed into <head>, whose content is discarded for this page: put the tag after the page's first body content (a leading config comment does not count)", typ)
+	}
+	args, err := splitArgs(e.AttrOr(dataArgsAttr, ""))
+	if err != nil {
+		return fmt.Errorf("invalid %s for script type %q: %w", dataArgsAttr, typ, err)
+	}
+	cmd := exec.Command(PluginPrefix+name, args...)
+	cmd.Stdin = strings.NewReader(e.Text())
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("plugin %s%s failed for script type %q: %w", PluginPrefix, name, typ, err)
+	}
+	// Parse with the tag's own parent as context - the same thing
+	// ReplaceWithHtml does internally - but keep the resulting node slice
+	// so its length is observable: in <head>, HTML5 only has real
+	// insertion-mode cases for a handful of elements (meta, link, base,
+	// style, title, script); anything else silently produces zero nodes
+	// instead of an error (verified against x/net/html/parse.go: the
+	// implied </head> empties the fragment's node stack, and the
+	// subsequent implied <body> is appended to the document itself, not
+	// to the fragment root, because addChild's insertion point falls back
+	// to the document when the stack is empty). That would otherwise be
+	// silent, unrecoverable data loss - the exact failure mode this
+	// feature must not have.
+	nodes, err := html5.ParseFragment(strings.NewReader(string(out)), e.Get(0).Parent)
+	if err != nil {
+		return fmt.Errorf("plugin %s%s produced unparseable output for script type %q: %w", PluginPrefix, name, typ, err)
+	}
+	if len(nodes) == 0 && strings.TrimSpace(string(out)) != "" {
+		return fmt.Errorf("plugin %s%s produced output that cannot be placed here (script type %q); inside <head> only meta, link, base, style and title are valid", PluginPrefix, name, typ)
+	}
+	e.ReplaceWithNodes(nodes...)
+	return nil
+}
+
+// argSeparators is the byte set splitArgs treats as unquoted field
+// separators: HTML5's own attribute whitespace plus \v, so a data-args
+// value wrapped across source lines splits the way it reads.
+const argSeparators = " \t\n\r\f\v"
+
+// splitArgs splits a data-args attribute value into argv using a small
+// POSIX-shell-like quoting grammar: unquoted whitespace separates fields,
+// 'literal quotes' preserve everything including whitespace and
+// backslashes verbatim, "quotes allow \" and \\ escapes", and a bare
+// backslash escapes the next byte outside quotes. Quotes are removal-only
+// (a"b"c splits to one field, abc); an empty quoted pair - single or
+// double - is one empty-string field.
+//
+// This is hand-rolled rather than a dependency (google/shlex is untagged
+// and unmaintained since 2019, and this package just finished getting off
+// unmaintained YAML dependencies) or a shell (nothing here is ever handed
+// to sh -c - exec.Command runs the plugin directly - so unlike a real
+// shell, none of $, `, *, ~, #, |, ;, &, <, > carry any special meaning;
+// they're always literal). An unterminated quote or a trailing backslash
+// is an error rather than a best-effort guess, matching this package's
+// reject-before-exec posture elsewhere (see pluginNameRe): guessing here
+// would mean handing a wrong argv to a program that executes.
+func splitArgs(s string) ([]string, error) {
+	var (
+		args    []string
+		cur     strings.Builder
+		started bool // a field has begun, even if still empty: "" must yield one empty arg
+	)
+	flush := func() {
+		if started {
+			args = append(args, cur.String())
+			cur.Reset()
+			started = false
+		}
+	}
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; {
+		case strings.IndexByte(argSeparators, c) >= 0:
+			flush()
+		case c == '\'':
+			started = true
+			j := strings.IndexByte(s[i+1:], '\'')
+			if j < 0 {
+				return nil, errors.New("unterminated single quote")
+			}
+			cur.WriteString(s[i+1 : i+1+j])
+			i += j + 1
+		case c == '"':
+			started = true
+			i++
+			for {
+				if i >= len(s) {
+					return nil, errors.New("unterminated double quote")
+				}
+				if s[i] == '"' {
+					break
+				}
+				if s[i] == '\\' && i+1 < len(s) && (s[i+1] == '"' || s[i+1] == '\\') {
+					i++
+				}
+				cur.WriteByte(s[i])
+				i++
+			}
+		case c == '\\':
+			if i+1 >= len(s) {
+				return nil, errors.New("trailing backslash")
+			}
+			started = true
+			i++
+			cur.WriteByte(s[i])
+		default:
+			started = true
+			cur.WriteByte(c)
+		}
+	}
+	flush()
+	return args, nil
+}

--- a/testdata/script-plugin-codeblock-site/.zas/config.yml
+++ b/testdata/script-plugin-codeblock-site/.zas/config.yml
@@ -1,0 +1,6 @@
+zas:
+  layout: .zas/layout.html
+  deploy: .zas/deploy
+site:
+  baseurl: http://example.com
+  language: en

--- a/testdata/script-plugin-codeblock-site/.zas/layout.html
+++ b/testdata/script-plugin-codeblock-site/.zas/layout.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><title>{{.Title}}</title></head>
+<body>
+{{.Body}}
+</body>
+</html>

--- a/testdata/script-plugin-codeblock-site/codeblock.md
+++ b/testdata/script-plugin-codeblock-site/codeblock.md
@@ -1,0 +1,6 @@
+<!-- title: Code -->
+# Code
+
+```html
+<script type="application/zas+echo"></script>
+```

--- a/testdata/script-plugin-head-site/.zas/config.yml
+++ b/testdata/script-plugin-head-site/.zas/config.yml
@@ -1,0 +1,6 @@
+zas:
+  layout: .zas/layout.html
+  deploy: .zas/deploy
+site:
+  baseurl: http://example.com
+  language: en

--- a/testdata/script-plugin-head-site/.zas/layout.html
+++ b/testdata/script-plugin-head-site/.zas/layout.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><title>{{.Title}}</title></head>
+<body>
+{{.Body}}
+</body>
+</html>

--- a/testdata/script-plugin-head-site/index.html
+++ b/testdata/script-plugin-head-site/index.html
@@ -1,0 +1,3 @@
+<!-- title: Head Trap -->
+<script type="application/zas+echo"></script>
+<p>after</p>

--- a/testdata/script-plugin-layout-site/.zas/config.yml
+++ b/testdata/script-plugin-layout-site/.zas/config.yml
@@ -1,0 +1,6 @@
+zas:
+  layout: .zas/layout.html
+  deploy: .zas/deploy
+site:
+  baseurl: http://example.com
+  language: en

--- a/testdata/script-plugin-layout-site/.zas/layout.html
+++ b/testdata/script-plugin-layout-site/.zas/layout.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>{{.Title}}</title>
+<script type="application/zas+meta"></script>
+</head>
+<body>
+{{.Body}}
+<script type="application/zas+echo" data-args="--tag footer 'from the layout itself'"></script>
+</body>
+</html>

--- a/testdata/script-plugin-layout-site/index.html
+++ b/testdata/script-plugin-layout-site/index.html
@@ -1,0 +1,2 @@
+<!-- title: Home -->
+<p>page content</p>

--- a/testdata/script-plugin-markdown-site/.zas/config.yml
+++ b/testdata/script-plugin-markdown-site/.zas/config.yml
@@ -1,0 +1,6 @@
+zas:
+  layout: .zas/layout.html
+  deploy: .zas/deploy
+site:
+  baseurl: http://example.com
+  language: en

--- a/testdata/script-plugin-markdown-site/.zas/layout.html
+++ b/testdata/script-plugin-markdown-site/.zas/layout.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><title>{{.Title}}</title></head>
+<body>
+{{.Body}}
+</body>
+</html>

--- a/testdata/script-plugin-markdown-site/data.md
+++ b/testdata/script-plugin-markdown-site/data.md
@@ -1,0 +1,8 @@
+<!-- title: Data -->
+# Data
+
+<script type="application/zas+wrap">
+name,count
+a,1
+b,2
+</script>

--- a/testdata/script-plugin-site/.zas/config.yml
+++ b/testdata/script-plugin-site/.zas/config.yml
@@ -1,0 +1,10 @@
+zas:
+  layout: .zas/layout.html
+  deploy: .zas/deploy
+site:
+  baseurl: http://example.com
+  language: en
+mimetypes:
+  text/markdown: markdown
+  text/plain: plain
+  text/html: html

--- a/testdata/script-plugin-site/.zas/layout.html
+++ b/testdata/script-plugin-site/.zas/layout.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>{{.Title}}</title>
+<script type="application/ld+json">{"@context": "https://schema.org"}</script>
+</head>
+<body>
+{{.Body}}
+</body>
+</html>

--- a/testdata/script-plugin-site/index.html
+++ b/testdata/script-plugin-site/index.html
@@ -1,0 +1,5 @@
+<!-- title: Script Plugins -->
+<h1>Script Plugins</h1>
+<script type="application/zas+echo" data-args="--tag b 'hello world'"></script>
+<script type="application/zas+wrap">{"k": "v"}</script>
+<script type="text/javascript">var pageJS = "a<b";</script>

--- a/testdata/script-plugin-site/partials/nav.html
+++ b/testdata/script-plugin-site/partials/nav.html
@@ -1,0 +1,2 @@
+<!-- publish: false -->
+<nav id="site-nav">nav from a plugin-emitted embed</nav>


### PR DESCRIPTION
## What this implements

The README has long documented invoking a `zs<name>` plugin from page content via `<script type="application/zas+name" data-args="...">`, but no such handling ever existed - only `<embed>` tags were processed. Git history confirms the text was written as spec in 2014 and never followed up with code.

## Why build it rather than delete the docs

`<script>` is an HTML5 raw-text element - its content survives byte for byte, never parsed as HTML. That lets a page carry an inline data block (JSON, CSV, YAML, anything) piped to a plugin's stdin and turned into HTML - something `<embed src="...">`'s file-only addressing structurally can't do. That capability, not just closing a docs/code mismatch, is why this is worth building.

## Decided scope

- Tag content **is** piped to stdin - a deliberate extension beyond the literal (empty-tag-only) README spec, and the feature's actual justification.
- `async` is **not** implemented. Every script tag runs synchronously in document order; the attribute is accepted but ignored. A second fan-out layer inside already-concurrent page rendering is exactly where this codebase has had race/goroutine-leak bugs before.
- `data-args` uses a small **hand-rolled** shell-like quoting splitter, not a dependency - `google/shlex` is untagged and unmaintained since 2019, and this repo just finished getting off unmaintained YAML deps.

## The `<head>` problem, and what it unlocked

HTML5 places a `<script>` written as the first thing in a page into `<head>`, not `<body>` - and a leading page-config comment doesn't prevent this. Splicing a plugin's output there naively is worse than it sounds: verified against `golang.org/x/net/html`'s parser that head-context fragment parsing only has real cases for a handful of elements; anything else triggers an implied `</head>` that empties the parse's node stack, and the implied `<body>` that follows lands on the *document*, not the fragment root - the parse returns **zero nodes**, and the plugin's output silently vanishes with no error.

The fix threads a `headFate` flag through `parseAndReplace`, recording whether the document being parsed is the one whose `<head>` actually reaches deployed output (true only for `Generate`'s pass over the assembled `layout.html`; false everywhere else). In a page's own content, head placement is refused outright - that head is always discarded regardless of output. In `layout.html`, it's allowed, and a plugin producing non-blank output that still parses to zero nodes is now a clear error instead of silent loss. This turns what would have been a documented limitation into a real, tested capability: **a `layout.html` plugin can inject `<meta>`/`<link>`/`<style>`/`<title>` into every deployed page's head.**

## Trust model

Reuses the existing `pluginNameRe` validation and the `-no-plugins` guard unchanged in spirit, now covering this as a third content-triggered exec path alongside `<embed>`'s `mzs*` mechanism. `Generator.NoPlugins`'s doc comment and the README's "Plugin trust model" section are updated to retract the now-false claim that `zs<name>` binaries are only ever argv-reachable - script tags let content name one directly.

## Found along the way, deliberately not folded in

The same head-placement behavior silently drops **any** leading `<script>` tag from deployed output - not just zas ones - a pre-existing pipeline characteristic this work happened to surface, unrelated to this feature. Flagged as a separate follow-up rather than expanding this PR's scope.

## Test plan

- [x] `go build ./...` / `go vet ./...` / `gofmt -l .` (clean) / `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./...` - full suite green, including 17 new unit tests (`splitArgs` grammar, stdin piping and non-decoding, `data-args` splitting, non-zas scripts left untouched, `-no-plugins`, both head-placement outcomes) and 9 new end-to-end tests against dedicated fixtures (page body, layout body, layout head, page-opening-script failure, `-no-plugins` failure, plugin-emitted embed resolution, fenced-code-block non-execution, a Markdown page)
- [x] Live repro with the real binary: an inline CSV block in a `<script type="application/zas+wrap">` tag reaches the plugin on stdin and gets replaced with its HTML output; `-no-plugins` refuses the same page naming both the flag and the plugin binary; a page-opening zas script tag fails the build with the `<head>` error rather than losing output silently; a real `<script>` and a JSON-LD block (with an `<h1>` before them, avoiding the separately-flagged pre-existing issue) deploy untouched