### PR TITLE
fix(generate): fail loudly when a page's own head-eligible content would be dropped

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ Zas still reads and processes `navigation.md` normally wherever it's embedded, b
 
 Every page goes through Zas's HTML5 parser twice: once on its own, to extract its body and settings, and once more after the layout wraps it, so any `<embed>` in the layout itself gets its turn too. Both passes re-serialize what they parse, and HTML5's parser is lenient by design - it repairs markup as it goes rather than rejecting it - so deployed output can differ mechanically from what you wrote: attributes get quoted, tag names get lowercased, void elements like `<img>`/`<br>` get self-closed, stray `&` characters get entity-escaped. Nothing is lost, and this is also why the embed mechanism above can splice arbitrary snippets together reliably - but don't expect deployed HTML to be a byte-for-byte copy of your source.
 
+One consequence of that first, page-only parse: HTML5 places a `<script>`, `<meta>`, `<link>`, `<base>`, `<style>`, or `<title>` written before any other real content into `<head>` rather than `<body>` - and a leading `<!-- key: value -->` config comment doesn't change that. Since only a page's `<body>` carries over into deployed output, such a tag would otherwise vanish silently; Zas instead fails the build for that page and names the tag. Put it after the page's first real content (even just an `<h1>`) and it renders exactly as written.
+
 ## 你会说普通话?
 
 對不起。T我不会说普通话。That's all my Chinese! If you are here, I guess you will enjoy I18N support in Zas.

--- a/generate.go
+++ b/generate.go
@@ -1176,6 +1176,22 @@ func (gen *Generator) render(path string, input []byte) (err error) {
 	if err != nil {
 		return
 	}
+	if lost := doc.Find(atom.Head.String()).Children(); lost.Length() > 0 {
+		// HTML5's tree construction sends a handful of elements (script,
+		// meta, link, base, style, title) straight into <head> when they're
+		// encountered before any real body content - even after a leading
+		// "<!-- key: value -->" config comment, which does not itself force
+		// body insertion mode. data.Body below is built solely from
+		// doc.Find("body").Html(), so anything the parser routed into <head>
+		// here would otherwise vanish from deployed output with no error or
+		// warning at all - a plausible trap for an ordinary page that opens
+		// with an analytics <script> or a JSON-LD block. Fail loudly instead.
+		var kinds []string
+		lost.Each(func(_ int, e *goquery.Selection) {
+			kinds = append(kinds, goquery.NodeName(e))
+		})
+		return fmt.Errorf("%s: parsed into <head> and would be silently dropped from the page: move it after the page's first real body content (a leading config comment does not count)", strings.Join(kinds, ", "))
+	}
 	gen.cleanUnnecessaryPTags(doc)
 	var pageErr error
 	data.Page, pageErr = gen.extractPageConfig(doc)

--- a/head_content_loss_test.go
+++ b/head_content_loss_test.go
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2013 Dario Castañé.
+ * This file is part of Zas.
+ *
+ * Zas is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Zas is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Zas.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package zas
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A page whose source opens with a <script> (or any other head-eligible
+// element - meta, link, base, style, title) before any real body content
+// used to have it silently vanish: HTML5's own tree construction routes
+// such elements into <head> rather than <body>, and render only ever keeps
+// doc.Find("body").Html() as data.Body. A leading "<!-- key: value -->"
+// config comment doesn't help either - it doesn't force body insertion
+// mode. Nothing surfaced this: no error, no warning, no trace. render must
+// now fail loudly instead.
+func TestRenderRejectsContentLostToHead(t *testing.T) {
+	gen := newRenderTestGenerator(t)
+	src := "<!-- title: T -->\n<script>var a = 1;</script>\n<p>hi</p>\n"
+
+	err := gen.render("index.html", []byte(src))
+	if err == nil {
+		t.Fatal("render() error = nil, want an error for content parsed into <head>")
+	}
+	if !strings.Contains(err.Error(), "script") || !strings.Contains(err.Error(), "<head>") {
+		t.Fatalf("render() error = %v, want it to name the lost element and mention <head>", err)
+	}
+
+	if _, statErr := os.Stat(filepath.Join("deploy", "index.html")); !os.IsNotExist(statErr) {
+		t.Fatalf("deploy output stat error = %v, want no output written for a rejected page", statErr)
+	}
+}
+
+// A <script> (or other head-eligible element) that comes after real body
+// content is parsed as ordinary body content, not routed into <head>, so it
+// must render exactly as written - this is the control case for
+// TestRenderRejectsContentLostToHead.
+func TestRenderKeepsScriptAfterRealBodyContent(t *testing.T) {
+	gen := newRenderTestGenerator(t)
+	src := "<!-- title: T -->\n<h1>Hi</h1>\n<script>var a = 1;</script>\n"
+
+	if err := gen.render("index.html", []byte(src)); err != nil {
+		t.Fatalf("render() error = %v, want nil", err)
+	}
+
+	out, err := os.ReadFile(filepath.Join("deploy", "index.html"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), "<script>var a = 1;</script>") {
+		t.Fatalf("deploy output = %q, want the script tag preserved", out)
+	}
+}


### PR DESCRIPTION
## Summary

Any page whose source opens with a head-eligible element (`<script>`, `<meta>`, `<link>`, `<base>`, `<style>`, `<title>`) before any real body content silently lost that element from deployed output, with no error or warning.

HTML5's own tree-construction algorithm places such an element into `<head>` rather than `<body>` when it's encountered before real body content - and a leading `<!-- key: value -->` config comment doesn't force body-insertion mode either, so it doesn't help. `render` only ever builds `data.Body` from `doc.Find("body").Html()`, so whatever the parser routed into `<head>` was simply discarded, with no trace.

This is easy to trigger by accident - an analytics `<script>`, a JSON-LD block, or a stray `<meta>` written as the very first thing in a page's source - and previously failed completely silently.

`render` now inspects its own parsed `<head>` right after parsing the page and fails the build for that page with a clear error naming the lost element(s), instead of continuing to render an incomplete body. Content placed after the page's first real body content (even just an `<h1>`) is unaffected, since it's parsed as ordinary body content and never routed into `<head>` to begin with.

Also documented the constraint in the README, next to the existing double-parse/output-vs-source note it's closely related to.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./...` (all green, including two new regression tests: `TestRenderRejectsContentLostToHead`, `TestRenderKeepsScriptAfterRealBodyContent`)
- [x] Live-verified with the real binary: a page opening with `<script>var a = 1;</script>` now fails the build with a clear error and produces no deploy output; the same content preceded by an `<h1>` still builds successfully with the script intact in deployed output