### PR TITLE
Bundle several independent, mechanical doc/hygiene fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ If I can help you, you have an idea or you are using Zas in your projects, don't
 
 ## About
 
-Written by [Dario Castañé](https://dario.im).
+Written by [Dario Castañé](https://dario.cat).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ![Zas](http://i.imgur.com/e9abWRX.png)
+# ![Zas](https://i.imgur.com/e9abWRX.png)
 
 Most simple static site generator ever.
 
@@ -43,11 +43,11 @@ Yes. Enough. Your delightful site is on .zas/deploy. Enjoy.
 What is happening here? Well, Zas calls the `generate` subcommand by default. This subcommand accepts the following flags:
 
 * `-verbose`: print ALL the things!
-* `-full`: generate all the input files. By default, it has an incremental mode that keeps source and deploys directories in sync.
+* `-full`: generate all the input files. By default, it has an incremental mode that keeps source and deploys directories in sync - it also picks up changes to `layout.html`, `config.yml`, `i18n.yml`, and any `.zas.yml` in a page's own directory tree, not just the page's own source. One gap: a page pulling in another file via `<embed>` is not regenerated when only the embedded file changes - use `-full` after editing an embedded file.
 
 ## Configuration and extension
 
-Zas is like water. It can flow, or it can cr... Nah, Zas doesn't crash (please fill an issue if it does).
+Zas is like water. It can flow, or it can cr... Nah, Zas doesn't crash (please file an issue if it does).
 
 Everything is configurable at .zas/config.yml. It is initialized with default values every time you create a repository. Beware, it happens every time you execute init.
 
@@ -82,7 +82,7 @@ Also, plugins are free to use `.zas` directory for their own needs. I recommend 
 .zas
 +-- plugins
 |   +-- github.com
-|       +-- imdario
+|       +-- darccio
 |           +-- myplugin
 +-- ...    
 ```
@@ -194,7 +194,7 @@ Keep in mind that any file will be treated as a Go text template before any furt
 * `{{.FirstTitle}}`: the file's first H1 header text, before any `title` override is applied - what `{{.Title}}` falls back to. Same best-effort preview behavior as `{{.Page}}` when used from inside a page's own content, with one more guard: if the H1 itself is written as `<h1>{{.Title}}</h1>`, the preview is deliberately left unavailable there instead of echoing the literal, unexecuted `{{.Title}}` text back into itself.
 * `{{.Directory}}`: YAML map from above (up to project's directory) or current directory's `.zas.yml` file. It is optional.
 * `{{.URL}}`: full URL for this file.
-* `{{.Extra /path/}}`: direct access to map holding `.zas/config.yml` as it is. You can access to any value with its full path. E.g. BaseURL is also available as `/site/baseurl`.
+* `{{.Extra "/path/"}}`: direct access to map holding `.zas/config.yml` as it is. You can access to any value with its full path. E.g. BaseURL is also available as `/site/baseurl`.
 * `{{.Resolve id}}`: indirect access to site, directory and page config. It works with simple keys (no paths), checking for them in page, directory and site config (as `/site/<id>`), in this order.
 * `{{.Language}}`: file current language, if defined in the first comment (as YAML property `language`). By default, `/site/language` value.
 * `{{.E "Some key"}}`: translates a string for the page's resolved language (see I18N below), falling back to `**Some key**` when no translation is found. Takes optional `fmt.Sprintf`-style arguments: `{{.E "Hello, %s" .Name}}`.
@@ -270,7 +270,7 @@ One consequence of that first, page-only parse: HTML5 places a `<script>`, `<met
 
 ## 你会说普通话?
 
-對不起。T我不会说普通话。That's all my Chinese! If you are here, I guess you will enjoy I18N support in Zas.
+對不起。我不会说普通话。That's all my Chinese! If you are here, I guess you will enjoy I18N support in Zas.
 
 ### I18N?
 
@@ -347,7 +347,7 @@ If I can help you, you have an idea or you are using Zas in your projects, don't
 
 ## About
 
-Written by [Dario Castañé](http://dario.im).
+Written by [Dario Castañé](https://dario.im).
 
 ## License
 

--- a/generate.go
+++ b/generate.go
@@ -668,21 +668,20 @@ func (gen *Generator) reaper(path string, _ os.FileInfo, err error) (ierr error)
 		}
 		return err
 	}
-	sourcePath := strings.Replace(path, gen.GetDeployPath(), ".", 1)
-	source, err := os.Open(sourcePath)
-	// TODO it must clean directories too
+	sourcePath := "." + strings.TrimPrefix(path, gen.GetDeployPath())
+	_, err = os.Stat(sourcePath)
 	if err != nil {
 		reap := true
 		if hasExtension(sourcePath, ".html") {
 			// swapExtension always normalizes to's own casing, so this
 			// guess (e.g. "./page.md") can only ever be lowercase,
 			// regardless of what case the real source used - a plain
-			// os.Open here would never find a differently-cased source
+			// os.Stat here would never find a differently-cased source
 			// like "PAGE.MD" on a case-sensitive filesystem. Note this
 			// isn't needed above: an .html-sourced deploy path is never
 			// extension-swapped at all (swapExtension's from is always
 			// ".md"), so it keeps the source's exact original casing, and
-			// plain os.Open above already matches it correctly.
+			// plain os.Stat above already matches it correctly.
 			sourcePath = swapExtension(sourcePath, ".html", ".md")
 			if gen.existsFold(sourcePath) {
 				reap = false
@@ -701,8 +700,6 @@ func (gen *Generator) reaper(path string, _ os.FileInfo, err error) (ierr error)
 				gen.reapedDirs[path] = struct{}{}
 			}
 		}
-	} else {
-		_ = source.Close()
 	}
 	return
 }

--- a/generate.go
+++ b/generate.go
@@ -1306,7 +1306,7 @@ func (gen *Generator) getTitle(doc *goquery.Document) (title string) {
 }
 
 /*
- * Extracts first HTML commend as map. It expects it as a valid YAML map.
+ * Extracts first HTML comment as map. It expects it as a valid YAML map.
  *
  * The config comment is looked for among the document's top-level nodes
  * (Doctype, comments, the <html> element, ...), not just the literal first

--- a/subcommand.go
+++ b/subcommand.go
@@ -25,8 +25,9 @@ import (
 
 // Subcommand is a Zas internal subcommand, inspired by the go command.
 type Subcommand struct {
-	// Runs the subcommand
-	// The args are the arguments after the subcommand name.
+	// Run runs the subcommand. It takes no arguments - flags are package
+	// globals wired up in init() - and returns an error instead of
+	// panicking or exiting directly.
 	Run func() error
 
 	// UsageLine is the one-line usage message.


### PR DESCRIPTION
## Summary
A bundle of small, independent, zero-risk fixes surfaced during a reconciliation pass over previously partially-fixed audit findings. Each change stands alone and carries no behavior risk beyond what's described:

- Reaper: existence check now uses `os.Stat` instead of `os.Open`+`Close`, deploy-path-prefix stripping now uses `strings.TrimPrefix` instead of a single-occurrence `strings.Replace`, and a stale "must clean directories too" TODO is removed (the existing `os.RemoveAll` already handles directories).
- `Subcommand.Run`'s doc comment now describes its actual signature (no arguments, returns an error) instead of a stale args contract.
- A "commend" -> "comment" typo fix in an unrelated doc comment.
- Several independent README nits: https links for the logo/author, a short caveat that incremental mode doesn't track `<embed>`-target changes, "please fill an issue" -> "please file an issue", a stray character removed from the closing Chinese sentence, a stale example username updated, and an unquoted template example argument quoted (the only form that's actually valid Go template syntax).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` clean
- [x] `golangci-lint run ./...` clean (0 issues)
- [x] `go test -race -count=1 ./...` green
- [x] Live repro: built the binary, generated a fixture with both a single leaf page and a subdirectory with two pages, removed both, ran an incremental `generate` - both cleanly reaped, deploy tree empty afterward, exit 0 (confirms the reaper refactor is behavior-preserving)