### PR TITLE
fix(zas): guard init against clobbering config and scaffold a layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Go to your site's directory and do:
 zas init
 ```
 
-Zas will create a `.zas` directory with sane defaults. Put your layout in `.zas/layout.html`, and you are good to go.
+Zas will create a `.zas` directory with sane defaults, including a starter `.zas/layout.html` - replace it with your own whenever you like.
 
 ```sh
 zas
@@ -49,7 +49,7 @@ What is happening here? Well, Zas calls the `generate` subcommand by default. Th
 
 Zas is like water. It can flow, or it can cr... Nah, Zas doesn't crash (please fill an issue if it does).
 
-Everything is configurable at .zas/config.yml. It is initialized with default values every time you create a repository. Beware, it happens every time you execute init.
+Everything is configurable at .zas/config.yml. It is initialized with default values the first time you run `zas init`; running it again leaves an existing config.yml (and layout.html) alone unless you pass `-force`, which overwrites both with their defaults.
 
 You can override the `site` config section in two ways:
 

--- a/cmd/zas/main.go
+++ b/cmd/zas/main.go
@@ -41,9 +41,9 @@ var subcommands = []*zas.Subcommand{
 }
 
 var (
-	verbose, full, noPlugins *bool
-	cmdInit                  = zas.NewSubcommand("init - create a new Zas site in the current directory", func() error {
-		i := zas.Init{}
+	verbose, full, noPlugins, force *bool
+	cmdInit                         = zas.NewSubcommand("init - create a new Zas site in the current directory", func() error {
+		i := zas.Init{Force: *force}
 		return i.Run()
 	})
 	cmdGenerate = zas.NewSubcommand("generate - render the site from source into the deploy directory", func() error {
@@ -64,6 +64,7 @@ func init() {
 	verbose = cmdGenerate.Flag.Bool("verbose", false, "Verbose output")
 	full = cmdGenerate.Flag.Bool("full", false, "Full generation (non-incremental mode)")
 	noPlugins = cmdGenerate.Flag.Bool("no-plugins", false, "Disable content-triggered plugin execution: <embed> MIME-type plugins and application/zas+ script tags (see README's \"Plugins\" section)")
+	force = cmdInit.Flag.Bool("force", false, "Overwrite an existing config.yml/layout.html with scaffolded defaults instead of leaving them untouched")
 
 	cmdHelp.Run = func() error {
 		printUsage(os.Stdout)

--- a/constants.go
+++ b/constants.go
@@ -57,14 +57,15 @@ const (
 	DefaultFilePerm os.FileMode = 0o644
 )
 
-// ConfigFile and I18nFile are a site's config and i18n file paths, relative
-// to its root. They can't be Go constants because filepath.Join isn't a
-// constant expression - but building them with filepath.Join, rather than
-// hand-concatenating with "/", is what keeps them correct on Windows, where
-// the OS path separator is "\\".
+// ConfigFile, I18nFile and LayoutFile are a site's config, i18n and default
+// layout file paths, relative to its root. They can't be Go constants
+// because filepath.Join isn't a constant expression - but building them
+// with filepath.Join, rather than hand-concatenating with "/", is what
+// keeps them correct on Windows, where the OS path separator is "\\".
 var (
 	ConfigFile = filepath.Join(Dir, "config.yml")
 	I18nFile   = filepath.Join(Dir, "i18n.yml")
+	LayoutFile = filepath.Join(Dir, "layout.html")
 )
 
 // defaultConfig is the built-in configuration merged into every site's own
@@ -74,7 +75,7 @@ var (
 // mutate it (or one of its nested section maps) through the returned value.
 var defaultConfig = ConfigSection{
 	Name: ConfigSection{
-		"layout": filepath.Join(Dir, "layout.html"),
+		"layout": LayoutFile,
 		"deploy": filepath.Join(Dir, "deploy"),
 	},
 	"site": ConfigSection{

--- a/init.go
+++ b/init.go
@@ -157,12 +157,35 @@ func (cs ConfigSection) GetZString(key string) string {
 	return s.GetString(key)
 }
 
+// defaultLayout is the minimal html/template document scaffolded as
+// LayoutFile by Init.Run: just enough for "zas init && zas" to succeed
+// standalone, matching the README's quickstart. Modeled on the smallest
+// layouts under testdata (e.g. testdata/walk-error-base/.zas/layout.html),
+// it renders each page's title and body and nothing else - it's a
+// starting point, not a real design.
+const defaultLayout = `<!DOCTYPE html>
+<html>
+<head><title>{{.Title}}</title></head>
+<body>
+{{.Body}}
+</body>
+</html>
+`
+
 // Init implements the "init" subcommand, which scaffolds a new Zas
 // repository in the current directory.
-type Init struct{}
+type Init struct {
+	// Force, when true, makes Run overwrite an existing ConfigFile or
+	// LayoutFile with its scaffolded default. When false (the default),
+	// Run leaves either file alone if it already exists, so re-running
+	// "zas init" on a site never silently discards hand-edited content.
+	Force bool
+}
 
-// Run scaffolds Dir and writes a default ConfigFile, overwriting
-// any existing one.
+// Run scaffolds Dir, and writes a default ConfigFile and LayoutFile.
+// Without Force set, an existing ConfigFile or LayoutFile is left
+// untouched (Run says so rather than staying silent about it); with
+// Force set, both are overwritten unconditionally.
 func (i *Init) Run() error {
 	path, err := filepath.Abs(Dir)
 	if err != nil {
@@ -176,11 +199,29 @@ func (i *Init) Run() error {
 	} else {
 		fmt.Printf("Reinitialized existing %s repository in %s\n", DisplayName, path)
 	}
-	// Stores DefaultConfig() as ConfigFile (as defined in
-	// constants.go). Overwrites every time we invoke the init subcommand.
-	data, err := yaml.Marshal(DefaultConfig())
+	config, err := yaml.Marshal(DefaultConfig())
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(ConfigFile, data, DefaultFilePerm)
+	if err := i.writeScaffold(ConfigFile, config); err != nil {
+		return err
+	}
+	return i.writeScaffold(LayoutFile, []byte(defaultLayout))
+}
+
+// writeScaffold writes data to path, creating or overwriting it, unless
+// path already exists and Force is false - in which case it leaves the
+// existing file untouched and prints that it did, instead of silently
+// discarding whatever is there.
+func (i *Init) writeScaffold(path string, data []byte) error {
+	if !i.Force {
+		switch _, statErr := os.Stat(path); {
+		case statErr == nil:
+			fmt.Printf("%s already exists, not overwriting (use -force to overwrite)\n", path)
+			return nil
+		case !os.IsNotExist(statErr):
+			return statErr
+		}
+	}
+	return os.WriteFile(path, data, DefaultFilePerm)
 }

--- a/init_run_test.go
+++ b/init_run_test.go
@@ -31,3 +31,108 @@ func TestInitRunOK(t *testing.T) {
 		t.Fatalf("config.yml not written: %v", err)
 	}
 }
+
+// Init.Run must scaffold a layout.html alongside config.yml, so that the
+// documented "zas init && zas" quickstart succeeds without a manual step.
+func TestInitRunScaffoldsLayout(t *testing.T) {
+	t.Chdir(t.TempDir())
+	i := &Init{}
+	if err := i.Run(); err != nil {
+		t.Fatalf("Init.Run() error = %v, want nil", err)
+	}
+	if _, err := os.Stat(LayoutFile); err != nil {
+		t.Fatalf("layout.html not written: %v", err)
+	}
+}
+
+// Without Force, Init.Run must not overwrite an existing config.yml: a
+// second "zas init" must never silently discard hand-edited configuration.
+func TestInitRunWithoutForceLeavesExistingConfigUntouched(t *testing.T) {
+	t.Chdir(t.TempDir())
+	i := &Init{}
+	if err := i.Run(); err != nil {
+		t.Fatalf("Init.Run() error = %v, want nil", err)
+	}
+
+	custom := []byte("zas:\n  layout: custom.html\nsite:\n  baseurl: https://example.org\n")
+	if err := os.WriteFile(ConfigFile, custom, DefaultFilePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := i.Run(); err != nil {
+		t.Fatalf("Init.Run() error = %v, want nil", err)
+	}
+
+	got, err := os.ReadFile(ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(custom) {
+		t.Fatalf("config.yml was overwritten without -force: got %q, want %q", got, custom)
+	}
+}
+
+// Without Force, Init.Run must likewise leave an existing layout.html
+// untouched.
+func TestInitRunWithoutForceLeavesExistingLayoutUntouched(t *testing.T) {
+	t.Chdir(t.TempDir())
+	i := &Init{}
+	if err := i.Run(); err != nil {
+		t.Fatalf("Init.Run() error = %v, want nil", err)
+	}
+
+	custom := []byte("<html><body>custom layout {{.Body}}</body></html>")
+	if err := os.WriteFile(LayoutFile, custom, DefaultFilePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := i.Run(); err != nil {
+		t.Fatalf("Init.Run() error = %v, want nil", err)
+	}
+
+	got, err := os.ReadFile(LayoutFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(custom) {
+		t.Fatalf("layout.html was overwritten without -force: got %q, want %q", got, custom)
+	}
+}
+
+// With Force set, Init.Run must overwrite an existing config.yml and
+// layout.html with the scaffolded defaults.
+func TestInitRunWithForceOverwritesExisting(t *testing.T) {
+	t.Chdir(t.TempDir())
+	i := &Init{}
+	if err := i.Run(); err != nil {
+		t.Fatalf("Init.Run() error = %v, want nil", err)
+	}
+
+	if err := os.WriteFile(ConfigFile, []byte("stale config"), DefaultFilePerm); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(LayoutFile, []byte("stale layout"), DefaultFilePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	forced := &Init{Force: true}
+	if err := forced.Run(); err != nil {
+		t.Fatalf("Init.Run() error = %v, want nil", err)
+	}
+
+	gotConfig, err := os.ReadFile(ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotConfig) == "stale config" {
+		t.Fatal("config.yml was not overwritten with -force")
+	}
+
+	gotLayout, err := os.ReadFile(LayoutFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotLayout) == "stale layout" {
+		t.Fatal("layout.html was not overwritten with -force")
+	}
+}


### PR DESCRIPTION
## Summary
- `zas init` no longer silently overwrites an existing `.zas/config.yml` (or `.zas/layout.html`) on a second run: without `-force` it leaves the existing file alone and prints that it did (`<path> already exists, not overwriting (use -force to overwrite)`); `-force` opts explicitly into overwriting both with their defaults.
- `zas init` now scaffolds a minimal `.zas/layout.html` (a small valid `html/template` document referencing `{{.Title}}`/`{{.Body}}`), so the documented quickstart (`zas init` && `zas`) succeeds standalone with no manual step.
- README's quickstart and configuration sections updated to match the new behavior.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./...` (all packages pass)
- [x] Live repro with a built binary in a scratch directory: `zas init && zas generate` succeeds standalone (no manual layout step); hand-edited `.zas/config.yml` survives a second `zas init` with no flags (with a clear "not overwriting" message); `zas init -force` overwrites it back to defaults.
- [x] New regression tests in `init_run_test.go`: `TestInitRunScaffoldsLayout`, `TestInitRunWithoutForceLeavesExistingConfigUntouched`, `TestInitRunWithoutForceLeavesExistingLayoutUntouched`, `TestInitRunWithForceOverwritesExisting`.