### PR TITLE
build(i18n): vendor melvinmt/gt in-tree instead of depending on it

### DIFF
--- a/body_attrs_test.go
+++ b/body_attrs_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/melvinmt/gt"
+	"github.com/darccio/zas/internal/i18n"
 )
 
 // data.Body carries only a source page's inner HTML, not its <body>
@@ -24,7 +24,7 @@ func TestRenderPreservesSourceBodyAttributes(t *testing.T) {
 	}
 	gen := &Generator{
 		Config: ConfigSection{"zas": ConfigSection{"deploy": "deploy"}},
-		I18n:   &gt.Build{Index: gt.Strings{}, Origin: "en"},
+		I18n:   &i18n.Build{Index: i18n.Strings{}, Origin: "en"},
 	}
 	layout, err := thtml.New("layout").Funcs(helpers).Parse(`<body class="layout">{{.Body}}</body>`)
 	if err != nil {
@@ -59,7 +59,7 @@ func TestRenderWithoutSourceBodyAttributesLeavesLayoutUnchanged(t *testing.T) {
 	}
 	gen := &Generator{
 		Config: ConfigSection{"zas": ConfigSection{"deploy": "deploy"}},
-		I18n:   &gt.Build{Index: gt.Strings{}, Origin: "en"},
+		I18n:   &i18n.Build{Index: i18n.Strings{}, Origin: "en"},
 	}
 	layout, err := thtml.New("layout").Funcs(helpers).Parse(`<body class="layout">{{.Body}}</body>`)
 	if err != nil {

--- a/data.go
+++ b/data.go
@@ -26,7 +26,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/melvinmt/gt"
+	"github.com/darccio/zas/internal/i18n"
 )
 
 // ZasData is the context data store used in templates.
@@ -70,7 +70,7 @@ type ZasData struct {
 	// Config loaded from ConfigFile.
 	config ConfigSection
 	// i18n helper
-	i18n *gt.Build
+	i18n *i18n.Build
 	// Attributes from the source page's own <body> tag (if any), merged
 	// onto the layout's <body> element since Body only carries the source
 	// body's inner HTML, not the element itself.
@@ -208,10 +208,10 @@ func NewZasData(srcPath string, gen *Generator) (data ZasData) {
 	// home page can still be recognized as one there too).
 	data.Path = "/" + filepath.ToSlash(srcPath)
 	data.config = gen.Config
-	// Each ZasData gets its own gt.Build sharing the (read-only, post-init)
+	// Each ZasData gets its own i18n.Build sharing the (read-only, post-init)
 	// Index, so per-render SetTarget/Translate calls don't race or bleed
 	// across languages on a Build shared by every render goroutine.
-	data.i18n = &gt.Build{
+	data.i18n = &i18n.Build{
 		Index:  gen.I18n.Index,
 		Origin: gen.I18n.Origin,
 	}

--- a/embed_depth_test.go
+++ b/embed_depth_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/melvinmt/gt"
+	"github.com/darccio/zas/internal/i18n"
 )
 
 // A file that embeds itself (directly, or through a cycle of mutually-
@@ -21,7 +21,7 @@ func TestRenderMarkdownSelfEmbedReturnsError(t *testing.T) {
 	}
 	gen := &Generator{
 		Config: ConfigSection{"mimetypes": ConfigSection{"text/markdown": "markdown"}},
-		I18n:   &gt.Build{Index: gt.Strings{}, Origin: "en"},
+		I18n:   &i18n.Build{Index: i18n.Strings{}, Origin: "en"},
 	}
 	err := gen.renderMarkdown("self.md")
 	if err == nil {

--- a/eq_helper_test.go
+++ b/eq_helper_test.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/melvinmt/gt"
+	"github.com/darccio/zas/internal/i18n"
 )
 
 // helpers used to register its own "eq", shadowing html/template's builtin
@@ -65,7 +65,7 @@ func TestLayoutEqOnUncomparableTypesReturnsCleanError(t *testing.T) {
 	}
 	gen := &Generator{
 		Config: ConfigSection{"zas": ConfigSection{"deploy": "deploy"}},
-		I18n:   &gt.Build{Index: gt.Strings{}, Origin: "en"},
+		I18n:   &i18n.Build{Index: i18n.Strings{}, Origin: "en"},
 	}
 	// eq on two slices is still an error either way (Execute aborts on
 	// error same as on a recovered panic), but the builtin rejects

--- a/generate.go
+++ b/generate.go
@@ -37,7 +37,7 @@ import (
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/melvinmt/gt"
+	"github.com/darccio/zas/internal/i18n"
 	markdown "github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/extension"
@@ -152,7 +152,7 @@ type Generator struct {
 	// Default layout from Config[Name]["layout"].
 	Layout *thtml.Template
 	// i18n helper.
-	I18n *gt.Build
+	I18n *i18n.Build
 	// layoutModTime, configModTime, and i18nModTime are the shared
 	// dependency files' mtimes, each captured once during Run's startup
 	// phase (parseLayout, Run, loadI18N) instead of being stat'd per page,
@@ -495,7 +495,7 @@ func (gen *Generator) loadI18N() {
 		gen.recordErr(err)
 		return
 	}
-	gen.I18n = &gt.Build{
+	gen.I18n = &i18n.Build{
 		Index:  i18nStrings,
 		Origin: mainlang,
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.26.0
 require (
 	dario.cat/mergo v1.0.2
 	github.com/PuerkitoBio/goquery v1.12.0
-	github.com/melvinmt/gt v1.0.1
 	github.com/yuin/goldmark v1.8.5
 	go.yaml.in/yaml/v3 v3.0.5
 	golang.org/x/net v0.58.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,6 @@ github.com/PuerkitoBio/goquery v1.12.0/go.mod h1:802ej+gV2y7bbIhOIoPY5sT183ZW0YF
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/melvinmt/gt v1.0.1 h1:0oYILl8UfvRc+OVRk7hymybPvCzOrmixuS46Dr/XzK8=
-github.com/melvinmt/gt v1.0.1/go.mod h1:fZvBmiukZgESIMCkh7O+D5uceNkOaAQmST1g8exnu/o=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/goldmark v1.8.5 h1:r6N5afV5qj/5S4UTch8agZHJ8UxNCMwX7WjkkJam2NA=
 github.com/yuin/goldmark v1.8.5/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=

--- a/i18n_args_test.go
+++ b/i18n_args_test.go
@@ -4,19 +4,19 @@ import (
 	thtml "html/template"
 	"testing"
 
-	"github.com/melvinmt/gt"
+	"github.com/darccio/zas/internal/i18n"
 )
 
-// Translate's arguments must be spread into gt.Translate's variadic
+// Translate's arguments must be spread into i18n.Build.Translate's variadic
 // parameter, not passed as a single []interface{} value - otherwise fmt's
 // verbs only ever see one argument (the slice itself), and any string with
-// more than one verb fails gt's verb/argument count check entirely.
+// more than one verb fails Translate's verb/argument count check entirely.
 
 func TestESpreadsSingleArgument(t *testing.T) {
 	zd := &ZasData{
 		Page: map[interface{}]interface{}{"language": "en"},
-		i18n: &gt.Build{
-			Index:  gt.Strings{"Hello %s": {"en": "Hello %s"}},
+		i18n: &i18n.Build{
+			Index:  i18n.Strings{"Hello %s": {"en": "Hello %s"}},
 			Origin: "en",
 		},
 	}
@@ -32,8 +32,8 @@ func TestESpreadsSingleArgument(t *testing.T) {
 func TestESpreadsMultipleArguments(t *testing.T) {
 	zd := &ZasData{
 		Page: map[interface{}]interface{}{"language": "en"},
-		i18n: &gt.Build{
-			Index: gt.Strings{
+		i18n: &i18n.Build{
+			Index: i18n.Strings{
 				"greeting": {"en": "Hello %s, you have %s messages"},
 			},
 			Origin: "en",
@@ -51,8 +51,8 @@ func TestESpreadsMultipleArguments(t *testing.T) {
 func TestHSpreadsArguments(t *testing.T) {
 	zd := &ZasData{
 		Page: map[interface{}]interface{}{"language": "en"},
-		i18n: &gt.Build{
-			Index:  gt.Strings{"Hello %s": {"en": "Hello %s"}},
+		i18n: &i18n.Build{
+			Index:  i18n.Strings{"Hello %s": {"en": "Hello %s"}},
 			Origin: "en",
 		},
 	}

--- a/i18n_race_test.go
+++ b/i18n_race_test.go
@@ -5,18 +5,18 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/melvinmt/gt"
+	"github.com/darccio/zas/internal/i18n"
 )
 
-// Every render used to share one *gt.Build, racing on SetTarget/
+// Every render used to share one *i18n.Build, racing on SetTarget/
 // Translate's internal fields and letting one page's language bleed into
 // another's. Run under `go test -race`; also asserts each goroutine only
 // ever observes its own language's translation.
 func TestZasDataTranslationConcurrentNoRace(t *testing.T) {
-	index := gt.Strings{
+	index := i18n.Strings{
 		"greeting": {"en": "Hello", "es": "Hola", "fr": "Bonjour"},
 	}
-	gen := &Generator{I18n: &gt.Build{Index: index, Origin: "en"}}
+	gen := &Generator{I18n: &i18n.Build{Index: index, Origin: "en"}}
 	want := map[string]string{"en": "Hello", "es": "Hola", "fr": "Bonjour"}
 
 	var wg sync.WaitGroup

--- a/init.go
+++ b/init.go
@@ -24,7 +24,7 @@ import (
 	"path/filepath"
 
 	"dario.cat/mergo"
-	"github.com/melvinmt/gt"
+	"github.com/darccio/zas/internal/i18n"
 	yaml "go.yaml.in/yaml/v3"
 )
 
@@ -87,28 +87,28 @@ func NewConfig() (ConfigSection, error) {
 
 // NewI18n loads I18nFile (as defined in constants.go).
 // It must be a YAML file.
-func NewI18n(mainlang string) (i18n gt.Strings, err error) {
+func NewI18n(mainlang string) (strs i18n.Strings, err error) {
 	data, err := os.ReadFile(I18nFile)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return make(gt.Strings), nil
+			return make(i18n.Strings), nil
 		}
 		return nil, err
 	}
-	i18n = make(gt.Strings)
-	if err = yaml.Unmarshal(data, &i18n); err != nil {
+	strs = make(i18n.Strings)
+	if err = yaml.Unmarshal(data, &strs); err != nil {
 		return nil, err
 	}
-	for k, v := range i18n {
+	for k, v := range strs {
 		if v == nil {
 			v = make(map[string]string)
-			i18n[k] = v
+			strs[k] = v
 		}
 		if _, ok := v[mainlang]; !ok {
 			v[mainlang] = k
 		}
 	}
-	return i18n, nil
+	return strs, nil
 }
 
 // GetString returns a string value from current section, or "" if key is

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2013 Melvin Tercan, https://github.com/melvinmt
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify,
+// merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+// Package i18n is a vendored, trimmed copy of github.com/melvinmt/gt v1.0.1
+// (unmaintained upstream since 2013). Only the Build/Strings surface zas
+// actually uses is kept; gt's own SetOrigin and T helpers were dropped as
+// dead code. Behavior is otherwise unchanged from upstream, including its
+// key-or-literal-string lookup, %verb argument swapping, and #tag stripping.
+package i18n
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+// Strings is a map type in the form of map[key]map[language][translation]
+type Strings map[string]map[string]string
+
+// Build sets up the translation environment. It must not be shared across
+// concurrent Translate/SetTarget calls for different targets: Target is an
+// unsynchronized field, and Translate's regex caches are lazily initialized
+// without locking.
+type Build struct {
+	Origin     string         // the origin env
+	Target     string         // the target env
+	Index      Strings        // the index which contains all keys and strings
+	regexVerbs *regexp.Regexp // caching regex Compiles
+	regexTags  *regexp.Regexp
+}
+
+// SetTarget is a shorthand method to set Target.
+func (b *Build) SetTarget(lang string) {
+	b.Target = lang
+}
+
+// Translate translates a key or string from origin to target.
+// Parses augmented sprintf format when additional arguments are given.
+func (b *Build) Translate(str string, args ...interface{}) (t string, err error) {
+	if b.Origin == "" {
+		b.Origin = "xx" // default
+	}
+
+	if b.Target == "" {
+		b.Target = "xx" // default
+	}
+
+	// Try to find origin string by key or key[:2]
+	var o string // origin string
+	key := str   // key can differ from str
+
+	if val, ok := b.Index[key][b.Origin]; ok {
+		o = val
+	} else if val, ok := b.Index[key][b.Origin[:2]]; ok {
+		o = val
+	} else {
+		// If key is not found, try matching strings in origin.
+		for k, m := range b.Index {
+			for l, v := range m {
+				if (l == b.Origin || l == b.Origin[:2]) && key == v {
+					o, key = v, k
+					break
+				}
+			}
+		}
+	}
+
+	// Try to find target string by key or key[:2]
+	if val, ok := b.Index[key][b.Target]; ok {
+		t = val
+	} else if val, ok := b.Index[key][b.Target[:2]]; ok {
+		t = val
+	}
+
+	if o == "" {
+		return b.parseString(str, args...), errors.New("couldn't find origin string")
+	}
+
+	if t == "" {
+		return b.parseString(o, args...), errors.New("couldn't find target string")
+	}
+
+	// When no additional arguments are given, there's nothing left to do.
+	if len(args) == 0 {
+		return b.cleanTags(t), err
+	}
+
+	// Find verbs in both strings.
+	if b.regexVerbs == nil {
+		b.regexVerbs = regexp.MustCompile(`%(?:\d+\$)?[+-]?(?:[ 0]|'.{1})?-?\d*(?:\.\d+)?#?[bcdeEfFgGopqstTuUvxX%]?[#[\w0-9-_]+]?`)
+	}
+	oVerbs := b.regexVerbs.FindAllStringSubmatch(o, -1)
+	tVerbs := b.regexVerbs.FindAllStringSubmatch(t, -1)
+
+	if len(oVerbs) != len(args) || len(tVerbs) != len(args) {
+		return b.parseString(o, args...), errors.New("arguments count is different than verbs count")
+	}
+
+	// Check if verbs are unique.
+	uniqueVerbs := true
+	q := make(map[string]int, len(tVerbs))
+	for _, v := range tVerbs {
+		if len(v) > 0 {
+			q[v[0]]++
+			if q[v[0]] > 1 {
+				uniqueVerbs = false
+				break
+			}
+		}
+	}
+
+	// Swap argument positions when swapping is necessary and verbs are unique.
+	if uniqueVerbs {
+		for i, v1 := range tVerbs {
+			for j, v2 := range oVerbs {
+				if len(args)-1 == i {
+					break
+				}
+				if v1[0] == v2[0] && args[i] != args[j] {
+					args[j], args[i] = args[i], args[j]
+					break
+				}
+			}
+		}
+	} else if h1, h2 := fmt.Sprintf("%v", oVerbs), fmt.Sprintf("%v", tVerbs); h1 != h2 {
+		return b.parseString(o, args...), errors.New("verbs have to be swapped but are not unique")
+	}
+
+	return b.parseString(t, args...), err
+}
+
+// parseString removes tags and parses arguments.
+func (b *Build) parseString(str string, args ...interface{}) (s string) {
+	s = b.cleanTags(str)
+	// Parse string.
+	s = fmt.Sprintf(s, args...)
+	return s
+}
+
+// cleanTags only removes tags.
+func (b *Build) cleanTags(str string) (s string) {
+	if b.regexTags == nil {
+		b.regexTags = regexp.MustCompile(`#[\w0-9-_]+`)
+	}
+	s = b.regexTags.ReplaceAllLiteralString(str, "")
+	return s
+}

--- a/internal/i18n/i18n_test.go
+++ b/internal/i18n/i18n_test.go
@@ -1,0 +1,431 @@
+// Copyright (c) 2013 Melvin Tercan, https://github.com/melvinmt
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify,
+// merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+// Ported from github.com/melvinmt/gt v1.0.1's own gt_test.go, minus the
+// SetOrigin/T coverage for the two helper methods this fork drops as
+// unused dead code (see i18n.go) - everything else is unchanged, pinning
+// this fork to upstream's exact translation behavior. TestNoTarget's
+// expected string was corrected from a pre-existing upstream typo -
+// verified against the actual, unmodified upstream package that its own
+// test already failed the same way, independent of this fork - the
+// literal text "%s(MISSING)" doesn't match fmt.Sprintf's real missing-
+// argument output, "%!s(MISSING)".
+package i18n
+
+import (
+	"testing"
+)
+
+func TestBuild(t *testing.T) {
+	g := &Build{
+		Index: Strings{
+			"homepage-greeting": {
+				"en":    "Welcome to %s#title, %s#name!",
+				"es-LA": "¡Bienvenido a %s#title, %s#title!",
+			},
+		},
+		Origin: "en",
+		Target: "es-LA",
+	}
+	if g.Origin != "en" {
+		t.Errorf("Origin = %q, want %q", g.Origin, "en")
+	}
+}
+
+func TestNoTargetString(t *testing.T) {
+	g := &Build{
+		Index: Strings{
+			"homepage-greeting": {
+				"en": "Welcome to %s#title, %s#name!",
+			},
+		},
+		Origin: "en",
+		Target: "es-LA",
+	}
+	func() {
+		t.Log("Test key")
+		s := "homepage-greeting"
+		tr, err := g.Translate(s, "gt", "Melvin")
+		if tr != "Welcome to gt, Melvin!" {
+			t.Errorf("Returned string '%s' is not Welcome to gt, Melvin!", tr)
+			t.Error(err)
+		}
+		if err == nil {
+			t.Error("Should return: could not find error")
+		}
+	}()
+	func() {
+		t.Log("Test string")
+		s := "Welcome to %s#title, %s#name!"
+		tr, err := g.Translate(s, "gt", "Melvin")
+		if tr != "Welcome to gt, Melvin!" {
+			t.Errorf("Returned string '%s' is not Welcome to gt, Melvin!", tr)
+		}
+		if err == nil {
+			t.Error("Should return: could not find error")
+		}
+	}()
+}
+
+func TestNoOriginString(t *testing.T) {
+	g := &Build{
+		Index: Strings{
+			"homepage-greeting": {
+				"es-LA": "¡Bienvenido a %s#title, %s#title!",
+			},
+		},
+		Origin: "en",
+		Target: "es-LA",
+	}
+	func() {
+		t.Log("Test key")
+		s := "homepage-greeting"
+		tr, err := g.Translate(s)
+		if s != tr {
+			t.Errorf("Returned string '%s' is not the same as input string '%s'", tr, s)
+		}
+		if err == nil {
+			t.Error("Should return: could not find error")
+		}
+	}()
+	func() {
+		t.Log("Test string")
+		s := "Welcome to %s#title, %s#name!"
+		tr, err := g.Translate(s, "gt", "Melvin")
+		if tr != "Welcome to gt, Melvin!" {
+			t.Errorf("Returned string '%s' is not the same as Welcome to gt, Melvin!", tr)
+		}
+		if err == nil {
+			t.Error("Should return: could not find error")
+		}
+	}()
+}
+
+func TestNoIndex(t *testing.T) {
+	g := &Build{
+		Origin: "en",
+		Target: "es-LA",
+	}
+	func() {
+		t.Log("Test key")
+		s := "homepage-greeting"
+		tr, err := g.Translate(s)
+		if s != tr {
+			t.Errorf("Returned string '%s' is not the same as input string '%s'", tr, s)
+		}
+		if err == nil {
+			t.Error("Should return: target or origin is not set")
+		}
+	}()
+	func() {
+		t.Log("Test string")
+		s := "Welcome to %s#title, %s#name!"
+		tr, err := g.Translate(s, "gt", "Melvin")
+		if tr != "Welcome to gt, Melvin!" {
+			t.Errorf("Returned string '%s' is not the same as Welcome to gt, Melvin!", tr)
+		}
+		if err == nil {
+			t.Error("Should return: target or origin is not set")
+		}
+	}()
+}
+
+func TestNoOrigin(t *testing.T) {
+	g := &Build{
+		Index: Strings{
+			"homepage-greeting": {
+				"en":    "Welcome to %s#title, %s#name!",
+				"es-LA": "¡Bienvenido a %s#title, %s#title!",
+			},
+		},
+		Target: "es-LA",
+	}
+	func() {
+		t.Log("Test key")
+		s := "homepage-greeting"
+		tr, err := g.Translate(s)
+		if s != tr {
+			t.Errorf("Returned string '%s' is not the same as input string '%s'", tr, s)
+		}
+		if err == nil {
+			t.Error(err)
+			t.Error("Should return: target or origin is not set")
+		}
+	}()
+	func() {
+		t.Log("Test string")
+		s := "Welcome to %s#title, %s#name!"
+		tr, err := g.Translate(s, "gt", "Melvin")
+		if tr != "Welcome to gt, Melvin!" {
+			t.Errorf("Returned string '%s' is not the same as Welcome to gt, Melvin!", tr)
+		}
+		if err == nil {
+			t.Error("Should return: target or origin is not set")
+		}
+	}()
+}
+
+func TestNoTarget(t *testing.T) {
+	g := &Build{
+		Index: Strings{
+			"homepage-greeting": {
+				"en":    "Welcome to %s#title, %s#name!",
+				"es-LA": "¡Bienvenido a %s#title, %s#title!",
+			},
+		},
+		Origin: "en",
+	}
+	func() {
+		t.Log("Test key")
+		s := "homepage-greeting"
+		tr, err := g.Translate(s)
+		if tr != "Welcome to %!s(MISSING), %!s(MISSING)!" {
+			t.Errorf("Returned string %q is not the same as %q", tr, "Welcome to %!s(MISSING), %!s(MISSING)!")
+		}
+		if err == nil {
+			t.Error("Should return: target or origin is not set")
+		}
+	}()
+	func() {
+		t.Log("Test string")
+		s := "Welcome to %s#title, %s#name!"
+		tr, err := g.Translate(s, "gt", "Melvin")
+		if tr != "Welcome to gt, Melvin!" {
+			t.Errorf("Returned string '%s' is not the same as Welcome to gt, Melvin!", tr)
+		}
+		if err == nil {
+			t.Error("Should return: target or origin is not set")
+		}
+	}()
+}
+
+func TestNoArgsTranslation(t *testing.T) {
+	g := &Build{
+		Index: Strings{
+			"homepage-greeting": {
+				"en":    "Welcome to gt!",
+				"es-LA": "¡Bienvenido a gt!",
+			},
+		},
+		Origin: "en",
+		Target: "es-LA",
+	}
+	func() {
+		t.Log("Test key")
+		s := "homepage-greeting"
+		tr, err := g.Translate(s)
+		if tr != "¡Bienvenido a gt!" {
+			t.Errorf("Returned string '%s' is not a translation of '%s'", tr, s)
+		}
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+	func() {
+		t.Log("Test key")
+		s := "Welcome to gt!"
+		tr, err := g.Translate(s)
+		if tr != "¡Bienvenido a gt!" {
+			t.Errorf("Returned string '%s' is not a translation of '%s'", tr, s)
+		}
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+}
+
+func TestArgsTranslationValidSyntax(t *testing.T) {
+	g := &Build{
+		Index: Strings{
+			"single": {
+				"en":    "Welcome to %s!",
+				"es-LA": "¡Bienvenido a %s!",
+			},
+			"multiple": {
+				"en":    "Welcome to %s, %s!",
+				"es-LA": "¡Bienvenido a %s, %s!",
+			},
+			"tags": {
+				"en":    "Welcome to %s#title-web_site, %s#name2!",
+				"es-LA": "¡Bienvenido a %s#title-web_site, %s#name2!",
+			},
+			"swap": {
+				"en":    "Welcome to %s#title-web_site, %s#name2!",
+				"es-LA": "¡Bienvenido a %s#name2, %s#title-web_site!",
+			},
+			"duplicate-same-order": {
+				"en":    "Welcome to %s#title-web_site, %s#name2! Your name is the same: %s#name2",
+				"es-LA": "¡Bienvenido a %s#title-web_site, %s#name2! Tu nombre es mismo: %s#name2",
+			},
+			"all-verbs": { // %b is duplicate but because it's in the same order (no swapping), no error is thrown
+				"en":    "Welcome to %v, %#v, %T, %%, %t, %b, %c, %d, %o, %q, %x, %X, %U, %b, %e, %f, %g, %G, %s, %+q, % d, %12d, %1.2f!",
+				"es-LA": "¡Bienvenido a %v, %#v, %T, %%, %t, %b, %c, %d, %o, %q, %x, %X, %U, %b, %e, %f, %g, %G, %s, %+q, % d, %12d, %1.2f!",
+			},
+			"all-verbs-tags": {
+				"en":    "Welcome to %v#t1, %#v#t2, %T#t3, %%, %t#t4, %b#t5, %c#t6, %d#t7, %o#t8, %q#t9, %x#t10, %X#t11, %U#t12, %b#t13, %e#t14, %f#t15, %g#t16, %G#t17, %s#t18, %+q#t19, % d#t20, %12d#t21, %1.2f#t22!",
+				"es-LA": "¡Bienvenido a %v#t1, %#v#t2, %T#t3, %%, %t#t4, %b#t5, %c#t6, %d#t7, %o#t8, %q#t9, %x#t10, %X#t11, %U#t12, %b#t13, %e#t14, %f#t15, %g#t16, %G#t17, %s#t18, %+q#t19, % d#t20, %12d#t21, %1.2f#t22!",
+			},
+			"all-verbs-different-order": { // notice I've removed a duplicate %b because that would cause a non unique swapping error
+				"en":    "Welcome to %v, %#v, %T, %%, %t, %c, %d, %o, %q, %x, %X, %U, %b, %e, %f, %g, %G, %s, %+q, % d, %12d, %1.2f!",
+				"es-LA": "¡Bienvenido a %b, %e, %f, %g, %G, %s, %+q, % d, %12d, %1.2f, %v, %#v, %T, %%, %t, %c, %d, %o, %q, %x, %X, %U!",
+			},
+			"all-verbs-tags-different-order": { // also notice we don't have this error with tags, because every tag provides an unique combination
+				"en":    "Welcome to %v#t1, %#v#t2, %T#t3, %%, %t#t4, %b#t5, %c#t6, %d#t7, %o#t8, %q#t9, %x#t10, %X#t11, %U#t12, %b#t13, %e#t14, %f#t15, %g#t16, %G#t17, %s#t18, %+q#t19, % d#t20, %12d#t21, %1.2f#t22!",
+				"es-LA": "¡Bienvenido a %e#t14, %f#t15, %g#t16, %G#t17, %s#t18, %+q#t19, % d#t20, %12d#t21, %1.2f#t22, %v#t1, %#v#t2, %T#t3, %%, %t#t4, %b#t5, %c#t6, %d#t7, %o#t8, %q#t9, %x#t10, %X#t11, %U#t12, %b#t13!",
+			},
+		},
+		Origin: "en",
+		Target: "es-LA",
+	}
+	func() {
+		t.Log("Test single verb")
+		s := "single"
+		tr, err := g.Translate(s, "gt")
+		if tr != "¡Bienvenido a gt!" {
+			t.Errorf("Returned string '%s' is not a translation of '%s'", tr, s)
+		}
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+	func() {
+		t.Log("Test multiple verbs")
+		s := "multiple"
+		tr, err := g.Translate(s, "gt", "Melvin")
+		if tr != "¡Bienvenido a gt, Melvin!" {
+			t.Errorf("Returned string '%s' is not a translation of '%s'", tr, s)
+		}
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+	func() {
+		t.Log("Test tags")
+		s := "tags"
+		tr, err := g.Translate(s, "gt", "Melvin")
+		if tr != "¡Bienvenido a gt, Melvin!" {
+			t.Errorf("Returned string '%s' is not a translation of '%s'", tr, s)
+		}
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	func() {
+		t.Log("Test swap tags")
+		s := "swap"
+		tr, err := g.Translate(s, "gt", "Melvin")
+		if tr != "¡Bienvenido a Melvin, gt!" {
+			t.Errorf("Returned string '%s' is not a translation of '%s'", tr, s)
+		}
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+	func() {
+		t.Log("Test duplicate verbs in same order")
+		s := "duplicate-same-order"
+		tr, err := g.Translate(s, "gt", "Melvin", "Melvin")
+		if tr != "¡Bienvenido a gt, Melvin! Tu nombre es mismo: Melvin" {
+			t.Errorf("Returned string '%s' is not a translation of '%s'", tr, s)
+		}
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+	func() {
+		t.Log("Test all types of verbs")
+		s := "all-verbs"
+		// "¡Bienvenido a %v, %#v, %T, %%, %t, %b, %c, %d, %o, %q, %x, %X, %U, %e, %f, %g, %G, %s, %+q, % d, %5d, %1.2f!",
+		_, err := g.Translate(s, "s1", "s2", "s3", true, 1, 2, 3, 4, 5, 6, 7, 8, 1.1, 1.2, 1.3, 1.4, 1.5, "s4", 8, 9, 10, 1.6)
+		// its almost impossible to test for str match so just checking for errors:
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+	func() {
+		t.Log("Test all types of verbs w/ tags")
+		s := "all-verbs-tags"
+		// "¡Bienvenido a %v, %#v, %T, %%, %t, %b, %c, %d, %o, %q, %x, %X, %U, %e, %f, %g, %G, %s, %+q, % d, %5d, %1.2f!",
+		_, err := g.Translate(s, "s1", "s2", "s3", true, 1, 2, 3, 4, 5, 6, 7, 8, 1.1, 1.2, 1.3, 1.4, 1.5, "s4", 8, 9, 10, 1.6)
+		// its almost impossible to test for str match so just checking for errors:
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+	func() {
+		t.Log("Test all types of verbs in different order")
+		s := "all-verbs-different-order"
+		// "¡Bienvenido a %v, %#v, %T, %%, %t, %b, %c, %d, %o, %q, %x, %X, %U, %e, %f, %g, %G, %s, %+q, % d, %5d, %1.2f!",
+		_, err := g.Translate(s, 1.1, 1.2, 1.3, 1.4, 1.5, "s4", 8, 9, 10, 1.6, "s1", "s2", "s3", true, 1, 3, 4, 5, 6, 7, 8)
+		// its almost impossible to test for str match so just checking for errors:
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+	func() {
+		t.Log("Test all types of verbs w/ tags in different order")
+		s := "all-verbs-tags-different-order"
+		// "¡Bienvenido a %v, %#v, %T, %%, %t, %b, %c, %d, %o, %q, %x, %X, %U, %e, %f, %g, %G, %s, %+q, % d, %5d, %1.2f!",
+		_, err := g.Translate(s, 1.1, 1.2, 1.3, 1.4, 1.5, "s4", 8, 9, 10, 1.6, "s1", "s2", "s3", true, 1, 2, 3, 4, 5, 6, 7, 8)
+		// its almost impossible to test for str match so just checking for errors:
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+}
+
+func TestArgsTranslationInvalidSyntax(t *testing.T) {
+	g := &Build{
+		Index: Strings{
+			"duplicate-different-order": {
+				"en":    "Welcome to %s#title-web_site, %s#name2! Your name is the same: %s#name2",
+				"es-LA": "¡Bienvenido a %s#name2, %s#title-web_site! Tu nombre es mismo: %s#name2",
+			},
+		},
+		Origin: "en",
+		Target: "es-LA",
+	}
+	func() {
+		t.Log("Test duplicate verbs in different order")
+		s := "Welcome to %s#title-web_site, %s#name2! Your name is the same: %s#name2"
+		tr, err := g.Translate(s, "gt", "Melvin", "Melvin")
+		if tr != "Welcome to gt, Melvin! Your name is the same: Melvin" {
+			t.Errorf("Returned string '%s' is not the same as Welcome to gt, Melvin! Your name is the same: Melvin", tr)
+		}
+		if err == nil {
+			t.Error("Should return Verbs have to be swapped but are not unique error")
+		}
+	}()
+}
+
+func TestSetTarget(t *testing.T) {
+	g := &Build{
+		Index: Strings{
+			"duplicate-different-order": {
+				"en":    "Welcome to %s#title-web_site, %s#name2! Your name is the same: %s#name2",
+				"es-LA": "¡Bienvenido a %s#name2, %s#title-web_site! Tu nombre es mismo: %s#name2",
+			},
+		},
+	}
+	g.Target = "en"
+	g.SetTarget("es")
+	if g.Target != "es" {
+		t.Errorf("SetTarget did not update Target: got %q, want %q", g.Target, "es")
+	}
+}

--- a/page_data_test.go
+++ b/page_data_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	ttext "text/template"
 
-	"github.com/melvinmt/gt"
+	"github.com/darccio/zas/internal/i18n"
 )
 
 // text/template only exposes pointer-receiver methods (Title, URL, E, H,
@@ -52,7 +52,7 @@ func TestZasDataPointerMethodsNeedAddressableValue(t *testing.T) {
 func TestNewZasDataBuildsForwardSlashPath(t *testing.T) {
 	gen := &Generator{
 		Config: ConfigSection{},
-		I18n:   &gt.Build{Index: gt.Strings{}, Origin: "en"},
+		I18n:   &i18n.Build{Index: i18n.Strings{}, Origin: "en"},
 	}
 	data := NewZasData(filepath.Join("sub", "page.html"), gen)
 	if want := "/sub/page.html"; data.Path != want {
@@ -70,7 +70,7 @@ func TestRenderPageBodyCanCallPointerReceiverMethod(t *testing.T) {
 			"zas":  ConfigSection{"deploy": "deploy"},
 			"site": ConfigSection{"baseurl": "http://example.com"},
 		},
-		I18n: &gt.Build{Index: gt.Strings{}, Origin: "en"},
+		I18n: &i18n.Build{Index: i18n.Strings{}, Origin: "en"},
 	}
 	layout, err := thtml.New("layout").Funcs(helpers).Parse(`{{.Body}}`)
 	if err != nil {
@@ -118,7 +118,7 @@ func testExtractPageConfigTitleOverride(t *testing.T, source string) {
 		Config: ConfigSection{
 			"zas": ConfigSection{"deploy": "deploy"},
 		},
-		I18n: &gt.Build{Index: gt.Strings{}, Origin: "en"},
+		I18n: &i18n.Build{Index: i18n.Strings{}, Origin: "en"},
 	}
 	layout, err := thtml.New("layout").Funcs(helpers).Parse(`{{.Title}}`)
 	if err != nil {

--- a/page_publish_test.go
+++ b/page_publish_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/melvinmt/gt"
+	"github.com/darccio/zas/internal/i18n"
 )
 
 // Coverage for the "publish: false" page-config key (upstream issue #15:
@@ -63,7 +63,7 @@ func TestRenderSkipsDeployOutputWhenPublishFalse(t *testing.T) {
 			"zas":  ConfigSection{"deploy": "deploy"},
 			"site": ConfigSection{"baseurl": "http://example.com"},
 		},
-		I18n: &gt.Build{Index: gt.Strings{}, Origin: "en"},
+		I18n: &i18n.Build{Index: i18n.Strings{}, Origin: "en"},
 	}
 	layout, err := thtml.New("layout").Funcs(helpers).Parse(`{{.Body}}`)
 	if err != nil {

--- a/raw_page_bench_test.go
+++ b/raw_page_bench_test.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/melvinmt/gt"
+	"github.com/darccio/zas/internal/i18n"
 )
 
 // largeBody is the body every "large" case below shares: big enough that a
@@ -87,7 +87,7 @@ func newRenderBenchGenerator(b *testing.B) *Generator {
 	}
 	gen := &Generator{
 		Config: ConfigSection{"zas": ConfigSection{"deploy": "deploy"}},
-		I18n:   &gt.Build{Index: gt.Strings{}, Origin: "en"},
+		I18n:   &i18n.Build{Index: i18n.Strings{}, Origin: "en"},
 	}
 	layout, err := thtml.New("layout").Funcs(helpers).Parse(`<body>{{.Body}}</body>`)
 	if err != nil {

--- a/raw_page_test.go
+++ b/raw_page_test.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/melvinmt/gt"
+	"github.com/darccio/zas/internal/i18n"
 )
 
 // utf16leBOM prepends a UTF-16LE byte-order mark and encodes s as
@@ -244,7 +244,7 @@ func newRenderTestGeneratorWithTitleLayout(t *testing.T) *Generator {
 	}
 	gen := &Generator{
 		Config: ConfigSection{"zas": ConfigSection{"deploy": "deploy"}},
-		I18n:   &gt.Build{Index: gt.Strings{}, Origin: "en"},
+		I18n:   &i18n.Build{Index: i18n.Strings{}, Origin: "en"},
 	}
 	layout, err := thtml.New("layout").Funcs(helpers).Parse(`<head><title>{{.Title}}</title></head><body>{{.Body}}</body>`)
 	if err != nil {

--- a/render_error_reporting_test.go
+++ b/render_error_reporting_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/melvinmt/gt"
+	"github.com/darccio/zas/internal/i18n"
 )
 
 // captureStderr is defined in symlink_test.go and reused here.
@@ -42,7 +42,7 @@ func newRenderTestGenerator(t *testing.T) *Generator {
 	}
 	gen := &Generator{
 		Config: ConfigSection{"zas": ConfigSection{"deploy": "deploy"}},
-		I18n:   &gt.Build{Index: gt.Strings{}, Origin: "en"},
+		I18n:   &i18n.Build{Index: i18n.Strings{}, Origin: "en"},
 	}
 	layout, err := thtml.New("layout").Funcs(helpers).Parse(`<body>{{.Body}}</body>`)
 	if err != nil {

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -3,7 +3,7 @@ package zas
 import (
 	"testing"
 
-	"github.com/melvinmt/gt"
+	"github.com/darccio/zas/internal/i18n"
 )
 
 // Extra must error both when a keypath segment isn't itself a section and
@@ -173,7 +173,7 @@ func TestURLWithoutTrailingSlashUnchanged(t *testing.T) {
 func TestEPropagatesLanguageError(t *testing.T) {
 	zd := &ZasData{
 		Page: map[interface{}]interface{}{"language": 5},
-		i18n: &gt.Build{},
+		i18n: &i18n.Build{},
 	}
 	if _, err := zd.E("greeting"); err == nil {
 		t.Fatal("E(): want error, got nil")
@@ -186,7 +186,7 @@ func TestEFallsBackOnMissingTranslation(t *testing.T) {
 	// the render.
 	zd := &ZasData{
 		Page: map[interface{}]interface{}{"language": "en"},
-		i18n: &gt.Build{Index: gt.Strings{}, Origin: "en"},
+		i18n: &i18n.Build{Index: i18n.Strings{}, Origin: "en"},
 	}
 	got, err := zd.E("missing.key")
 	if err != nil {


### PR DESCRIPTION
## Summary

- `melvinmt/gt` (zas's only i18n library) has had no upstream release since 2013 and shows no sign of maintenance — confirmed via `go list -m -u` (no newer version exists) and the upstream repository's own commit history. This left zas with no path to future bug fixes, security patches, or Go-version compatibility fixes for a dependency two other symptom bugs had already been found in.
- Chose to vendor it in-tree as `internal/i18n` rather than replace it with a different library or just document-and-accept the risk: the whole thing is 166 lines, one file, MIT-licensed, stdlib-only (no transitive deps, no network I/O, no binary parsing). Copying it in makes zas the de facto maintainer with **zero change** to the `i18n.yml` format or the `{{.E}}`/`{{.H}}` template contract. A replacement library would have a materially different, heavier API and would still need an adapter reimplementing gt's own quirks (key-or-literal lookup, `%verb` argument-swapping, `#tag` stripping) to avoid breaking existing sites — more code for no behavioral gain.
- The fork keeps only the `Build`/`Strings` surface zas actually uses (`SetOrigin` and `T` were unused, dropped as dead code). Its test suite is ported line-for-line from upstream's own `gt_test.go` to pin the exact translation behavior.
- One assertion in that ported suite expected a literal `"%s(MISSING)"` string that doesn't match `fmt.Sprintf`'s real missing-argument output, `"%!s(MISSING)"` — confirmed as a pre-existing upstream test bug by running it unmodified against the actual `melvinmt/gt v1.0.1` source (fails there too, independent of this fork) — corrected here.
- `go.mod`/`go.sum` drop the now-unused dependency.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./...` (all packages pass, including the new `internal/i18n` suite)
- [x] Live repro with the real binary: multi-language fixture site (`i18n.yml`, per-directory `.zas.yml` language, `{{.E}}`/`{{.H}}` in templates) — confirmed key-based lookup, verb-swapping across languages, `#tag` stripping, missing-key `**key**` fallback, and `{{.H}}` trusted-HTML all behave exactly as before