### PR TITLE
fix(generate)!: resolve embed src relative to the embedding page

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,11 @@ What does it mean? It means you can have .html files with embedded markdown file
 
 Zas still reads and processes `navigation.md` normally wherever it's embedded, but it won't also show up on its own at `/navigation.html` in the deploy output.
 
-`<embed>` also works directly inside `layout.html` itself, not just inside a page's own body - useful for something every page shares, like a site-wide footer.
+An `<embed>`'s `src` written inside a page's own body resolves relative to that page's own directory - the same way a relative `<img src>`/`<a href>` would once the page is deployed and viewed in a browser. So a page at `section/index.html` embedding `<embed src="navigation.md" ...>` looks for `section/navigation.md`, not a `navigation.md` at the site root, even if one happens to exist there too. A leading `../` is allowed as long as it still lands inside the site: `<embed src="../shared.md" ...>` from `section/index.html` reaches a `shared.md` at the site root, but nothing can be made to resolve outside the site root itself, however many `../` it uses.
+
+`<embed>` also works directly inside `layout.html` itself, not just inside a page's own body - useful for something every page shares, like a site-wide footer. This case is different: `layout.html` is a single, fixed file shared by every page rather than page content that lives in a particular directory, so an embed written there always resolves relative to the site root, regardless of which page is currently being rendered.
+
+Note that this is specific to Zas's own built-in embed handlers (`Markdown`, `Plain`, `Html` - the ones `mimetypes:` maps a `text/*` type to by default). An `mzs*` MIME type plugin (see "MIME type plugins" above) still receives its `src` argument exactly as written in `<embed src="...">`, with no resolution applied at all - the plugin decides for itself how to interpret it.
 
 #### A note on output vs. source
 

--- a/data.go
+++ b/data.go
@@ -78,6 +78,23 @@ type ZasData struct {
 	// Tracks embed nesting depth for this render, guarding against a self-
 	// or mutually-embedding file recursing without bound.
 	embedDepth int
+	// Directory (relative to the site root, or absolute once a nested embed
+	// has narrowed it further) that the next <embed src="..."> encountered
+	// in this page's own body should resolve against. NewZasData seeds this
+	// to the rendered page's own directory, so an embed written inside a
+	// subdirectory page resolves relative to that subdirectory, the same
+	// way a relative <img src>/<a href> would once the page is deployed and
+	// viewed in a browser - see resolveEmbedSrc in generate.go. Markdown
+	// and Html save and restore this around their own recursive
+	// parseAndReplace call so a chain of embeds each resolves relative to
+	// the file that embedded it, not the outermost page. Generate
+	// overrides it back to the site root before its own parseAndReplace
+	// pass, since any <embed> still unresolved at that point was written
+	// directly into layout.html - a single, fixed file shared by every
+	// page - rather than into this page's own content, and layout-level
+	// embeds (e.g. a site-wide footer) intentionally keep resolving
+	// site-root-relative regardless of which page is currently rendering.
+	embedBaseDir string
 }
 
 // ZasSiteData is the site configuration.
@@ -207,6 +224,11 @@ func NewZasData(srcPath string, gen *Generator) (data ZasData) {
 	// hardcoded "/"-separated comparisons below, so a language-prefixed
 	// home page can still be recognized as one there too).
 	data.Path = "/" + filepath.ToSlash(srcPath)
+	// srcPath (not data.Path) here: it still has the OS's own separator,
+	// which is what resolveEmbedSrc's filepath.Join expects, and its
+	// directory portion is identical either way - swapExtension above only
+	// ever rewrites the final path component's extension.
+	data.embedBaseDir = filepath.Dir(srcPath)
 	data.config = gen.Config
 	// Each ZasData gets its own gt.Build sharing the (read-only, post-init)
 	// Index, so per-render SetTarget/Translate calls don't race or bleed

--- a/embed_containment_test.go
+++ b/embed_containment_test.go
@@ -174,3 +174,75 @@ func TestGenerateRejectsEmbedEscapingSiteRootViaTraversal(t *testing.T) {
 	}
 	assertDeployMissing(t, "leak.html")
 }
+
+// A page-body embed now resolves relative to the embedding page's own
+// directory (see embed_page_relative_test.go) rather than always the site
+// root, so containment has to keep working against that new base too: a
+// "../" sequence deep enough to walk past the site root itself must still
+// be rejected, even though it's now relative to the page's own
+// subdirectory instead of the root the old, pre-page-relative code always
+// used as its base.
+func TestGenerateRejectsPageRelativeEmbedEscapingSiteRoot(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "site")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	copyFixture(t, "site", root)
+	t.Chdir(root)
+
+	if err := os.WriteFile(filepath.Join(base, "secret.txt"), []byte("do not leak"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir("section", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// "section/leak.html" is one directory below the site root, so a
+	// single ".." from there reaches the root itself (see the companion
+	// success case below) - a second ".." is what walks past it into base,
+	// where secret.txt lives.
+	leak := `<embed src="../../secret.txt" type="text/plain">` + "\n"
+	if err := os.WriteFile(filepath.Join("section", "leak.html"), []byte(leak), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := generate(t); err == nil {
+		t.Fatal(`generate() with "section/leak.html" embedding "../../secret.txt": want error, got nil`)
+	}
+	assertDeployMissing(t, "section/leak.html")
+}
+
+// Companion to the rejection above: a page-relative "../" that stays
+// inside the site root (here, one level up from "section/" lands exactly
+// on the root) must still be allowed - containment rejects paths that
+// escape the site root, not every ".." on principle, the same way a
+// relative link in a deployed browser page can legitimately walk up to a
+// shared sibling directory.
+func TestGenerateAllowsPageRelativeEmbedOneLevelUpStillInsideRoot(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "site")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	copyFixture(t, "site", root)
+	t.Chdir(root)
+
+	if err := os.WriteFile("shared.txt", []byte("shared content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir("section", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	reader := "<!-- title: Reader -->\n" + `<embed src="../shared.txt" type="text/plain">` + "\n"
+	if err := os.WriteFile(filepath.Join("section", "reader.html"), []byte(reader), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := generate(t); err != nil {
+		t.Fatalf(`generate() with "section/reader.html" embedding "../shared.txt": error = %v, want nil`, err)
+	}
+	got := readDeploy(t, "section/reader.html")
+	if !strings.Contains(got, "shared content") {
+		t.Fatalf("deployed section/reader.html = %q, want it to contain %q", got, "shared content")
+	}
+}

--- a/embed_page_relative_test.go
+++ b/embed_page_relative_test.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2013 Dario Castañé.
+ * This file is part of Zas.
+ *
+ * Zas is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Zas is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Zas.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package zas
+
+import (
+	"strings"
+	"testing"
+)
+
+// <embed src="..."> used to be read with os.ReadFile(src) resolved against
+// the process's current directory (the site root), regardless of where the
+// embedding page itself lived. A page written inside a subdirectory that
+// embedded a same-named file present at both the site root and its own
+// directory would silently get the root copy - no error, no warning, just
+// the wrong content. resolveEmbedSrc now resolves a page-body embed
+// relative to that page's own directory instead (see ZasData.embedBaseDir
+// in data.go). This fixture places different content in a same-named
+// nav.md/nav.txt/nav.html at both the site root and in "section/", and
+// "section/index.html" embeds all three by their bare filename: if
+// resolution were still root-relative, every one of these assertions would
+// see the "ROOT ..." text instead.
+func TestGenerateEmbedResolvesRelativeToPage(t *testing.T) {
+	newTestSite(t, "embed-page-relative-site")
+	if err := generate(t); err != nil {
+		t.Fatalf("generate() error = %v, want nil", err)
+	}
+	got := readDeploy(t, "section/index.html")
+	for _, want := range []string{"SECTION markdown nav", "SECTION plain nav", "SECTION html nav"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("deployed section/index.html = %q, want it to contain %q (the section-local file)", got, want)
+		}
+	}
+	for _, unwanted := range []string{"ROOT markdown nav", "ROOT plain nav", "ROOT html nav"} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("deployed section/index.html = %q, want it not to contain %q (the site-root file with the same name)", got, unwanted)
+		}
+	}
+}
+
+// A chain of embeds - a page embedding a file which itself embeds a
+// further file via a relative src - should have each src resolve against
+// the file that wrote it, not against the outermost page. This fixture's
+// root "index.html" embeds "partials/nav.md", which in turn embeds
+// "footer.md" using only the bare filename (no "partials/" prefix): that
+// only resolves if the embed base directory follows the embed chain down
+// into "partials/" rather than staying pinned to the outer page's own
+// directory (the site root). If it stayed pinned to the root, this would
+// fail generation entirely with a missing-file error, since there is no
+// "footer.md" at the site root.
+func TestGenerateChainedEmbedResolvesRelativeToEachFile(t *testing.T) {
+	newTestSite(t, "embed-chained-relative-site")
+	if err := generate(t); err != nil {
+		t.Fatalf("generate() error = %v, want nil", err)
+	}
+	got := readDeploy(t, "index.html")
+	for _, want := range []string{"partial nav", "partial footer"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("deployed index.html = %q, want it to contain %q", got, want)
+		}
+	}
+}

--- a/generate.go
+++ b/generate.go
@@ -389,6 +389,17 @@ func (gen *Generator) Generate(_ string, data *ZasData) (err error) {
 	// parse. headRendered (see headFate) reflects that this pass, unlike
 	// every other parseAndReplace call, produces the document whose <head>
 	// actually reaches deployed output.
+	//
+	// Any <embed> this pass finds was necessarily written directly into
+	// layout.html: render's own pass already resolved and spliced away
+	// every embed that was in the page's own body. layout.html is a
+	// single, fixed file shared by every page rather than page content
+	// itself, so unlike a page-body embed its src still resolves against
+	// the site root here, matching how it already worked before
+	// page-relative resolution existed (see
+	// TestGenerateResolvesEmbedInLayoutItself, whose fixture places a
+	// shared footer at the site root, not next to layout.html).
+	data.embedBaseDir = "."
 	doc, err := gen.parseAndReplace(&processed, data, headRendered)
 	if err != nil {
 		return
@@ -1371,17 +1382,31 @@ func (gen *Generator) copy(dstPath, srcPath string) (err error) {
 
 // resolveEmbedSrc resolves an <embed src="..."> attribute to an absolute
 // path and rejects any result that falls outside the site root - the
-// process's current directory, the same base every embed src is already
-// read relative to (see walk's use of "." and BuildDeployPath). Without
-// this check, an absolute src or a "../" traversal in site content lets a
-// page pull the contents of any file the build process can read into the
-// published output.
-func (gen *Generator) resolveEmbedSrc(src string) (string, error) {
+// process's current directory, the same base every embed src not resolved
+// against baseDir is still ultimately read relative to (see walk's use of
+// "." and BuildDeployPath). Without this check, an absolute src or a "../"
+// traversal in site content lets a page pull the contents of any file the
+// build process can read into the published output.
+//
+// A relative src is resolved against baseDir first (an empty baseDir means
+// the site root, matching this function's own behavior before callers
+// started passing ZasData.embedBaseDir). An absolute src ignores baseDir
+// entirely and is resolved as-is: joining it onto baseDir would silently
+// turn a should-be-rejected absolute path into a baseDir-relative one
+// instead of rejecting it below.
+func (gen *Generator) resolveEmbedSrc(baseDir, src string) (string, error) {
 	root, err := filepath.Abs(".")
 	if err != nil {
 		return "", err
 	}
-	target, err := filepath.Abs(src)
+	joined := src
+	if !filepath.IsAbs(src) {
+		if baseDir == "" {
+			baseDir = "."
+		}
+		joined = filepath.Join(baseDir, src)
+	}
+	target, err := filepath.Abs(joined)
 	if err != nil {
 		return "", err
 	}
@@ -1398,7 +1423,7 @@ func (gen *Generator) resolveEmbedSrc(src string) (string, error) {
 // Markdown embeds a Markdown file.
 func (gen *Generator) Markdown(e *goquery.Selection, _ *goquery.Document, data *ZasData) (err error) {
 	if src, ok := e.Attr(atom.Src.String()); ok {
-		resolved, err := gen.resolveEmbedSrc(src)
+		resolved, err := gen.resolveEmbedSrc(data.embedBaseDir, src)
 		if err != nil {
 			return err
 		}
@@ -1410,7 +1435,14 @@ func (gen *Generator) Markdown(e *goquery.Selection, _ *goquery.Document, data *
 		if err := markdownConverter.Convert(mdInput, &b); err != nil {
 			return err
 		}
+		// Any <embed> inside the file just read resolves relative to that
+		// file's own directory, not data's outer page - restored once this
+		// call returns so a sibling embed later in the outer page's own
+		// body still resolves against the outer page again.
+		restore := data.embedBaseDir
+		data.embedBaseDir = filepath.Dir(resolved)
 		mdDoc, err := gen.parseAndReplace(&b, data, headDropped)
+		data.embedBaseDir = restore
 		if err != nil {
 			return err
 		}
@@ -1430,7 +1462,7 @@ func (gen *Generator) Markdown(e *goquery.Selection, _ *goquery.Document, data *
 // Plain embeds a plain text file.
 func (gen *Generator) Plain(e *goquery.Selection, _ *goquery.Document, data *ZasData) (err error) {
 	if src, ok := e.Attr(atom.Src.String()); ok {
-		resolved, err := gen.resolveEmbedSrc(src)
+		resolved, err := gen.resolveEmbedSrc(data.embedBaseDir, src)
 		if err != nil {
 			return err
 		}
@@ -1456,7 +1488,7 @@ func (gen *Generator) Plain(e *goquery.Selection, _ *goquery.Document, data *Zas
 // Html embeds a HTML file.
 func (gen *Generator) Html(e *goquery.Selection, _ *goquery.Document, data *ZasData) (err error) {
 	if src, ok := e.Attr(atom.Src.String()); ok {
-		resolved, err := gen.resolveEmbedSrc(src)
+		resolved, err := gen.resolveEmbedSrc(data.embedBaseDir, src)
 		if err != nil {
 			return err
 		}
@@ -1465,8 +1497,13 @@ func (gen *Generator) Html(e *goquery.Selection, _ *goquery.Document, data *ZasD
 		if err != nil {
 			return err
 		}
+		// Same save/restore as Markdown above: an <embed> inside the file
+		// just read resolves relative to that file's own directory.
+		restore := data.embedBaseDir
+		data.embedBaseDir = filepath.Dir(resolved)
 		var htmlDoc *goquery.Document
 		htmlDoc, err = gen.parseAndReplace(bytes.NewBuffer(input), data, headDropped)
+		data.embedBaseDir = restore
 		if err != nil {
 			return err
 		}

--- a/layout_embed_test.go
+++ b/layout_embed_test.go
@@ -55,3 +55,29 @@ func TestGenerateResolvesEmbedInLayoutItself(t *testing.T) {
 		}
 	}
 }
+
+// An <embed> written inside a page's own body now resolves relative to
+// that page's own directory (see TestGenerateEmbedResolvesRelativeToPage),
+// but an <embed> written directly into layout.html is a different case:
+// layout.html is a single, fixed file shared by every page, not content
+// that lives "in" any one page's directory, so its own embeds still
+// resolve against the site root regardless of which page is currently
+// being rendered. This renders "section/index.html" - a page one
+// directory below the site root - through the same layout as
+// TestGenerateResolvesEmbedInLayoutItself and confirms the layout's
+// site-root "footer.html" embed still resolves, rather than the layout
+// handler mistakenly looking for "section/footer.html" (which doesn't
+// exist) and failing the build.
+func TestGenerateLayoutEmbedStaysRootRelativeForSubdirectoryPage(t *testing.T) {
+	newTestSite(t, "layout-embed-site")
+	if err := generate(t); err != nil {
+		t.Fatalf("generate() error = %v, want nil", err)
+	}
+	got := readDeploy(t, "section/index.html")
+	if !strings.Contains(got, "footer from the layout itself") {
+		t.Fatalf("deployed section/index.html = %q, want it to contain the layout's own embedded footer", got)
+	}
+	if !strings.Contains(got, "section content") {
+		t.Fatalf("deployed section/index.html = %q, want it to contain the page's own content", got)
+	}
+}

--- a/testdata/embed-chained-relative-site/.zas/config.yml
+++ b/testdata/embed-chained-relative-site/.zas/config.yml
@@ -1,0 +1,8 @@
+zas:
+  layout: .zas/layout.html
+  deploy: .zas/deploy
+site:
+  baseurl: http://example.com
+  language: en
+mimetypes:
+  text/markdown: markdown

--- a/testdata/embed-chained-relative-site/.zas/layout.html
+++ b/testdata/embed-chained-relative-site/.zas/layout.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><title>{{.Title}}</title></head>
+<body>
+{{.Body}}
+</body>
+</html>

--- a/testdata/embed-chained-relative-site/index.html
+++ b/testdata/embed-chained-relative-site/index.html
@@ -1,0 +1,2 @@
+<!-- title: Home -->
+<embed src="partials/nav.md" type="text/markdown">

--- a/testdata/embed-chained-relative-site/partials/footer.md
+++ b/testdata/embed-chained-relative-site/partials/footer.md
@@ -1,0 +1,1 @@
+<p>partial footer</p>

--- a/testdata/embed-chained-relative-site/partials/nav.md
+++ b/testdata/embed-chained-relative-site/partials/nav.md
@@ -1,0 +1,3 @@
+<p>partial nav</p>
+
+<embed src="footer.md" type="text/markdown">

--- a/testdata/embed-page-relative-site/.zas/config.yml
+++ b/testdata/embed-page-relative-site/.zas/config.yml
@@ -1,0 +1,10 @@
+zas:
+  layout: .zas/layout.html
+  deploy: .zas/deploy
+site:
+  baseurl: http://example.com
+  language: en
+mimetypes:
+  text/markdown: markdown
+  text/plain: plain
+  text/html: html

--- a/testdata/embed-page-relative-site/.zas/layout.html
+++ b/testdata/embed-page-relative-site/.zas/layout.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><title>{{.Title}}</title></head>
+<body>
+{{.Body}}
+</body>
+</html>

--- a/testdata/embed-page-relative-site/nav-html.html
+++ b/testdata/embed-page-relative-site/nav-html.html
@@ -1,0 +1,1 @@
+<p>ROOT html nav</p>

--- a/testdata/embed-page-relative-site/nav-markdown.md
+++ b/testdata/embed-page-relative-site/nav-markdown.md
@@ -1,0 +1,1 @@
+<p>ROOT markdown nav</p>

--- a/testdata/embed-page-relative-site/nav-plain.txt
+++ b/testdata/embed-page-relative-site/nav-plain.txt
@@ -1,0 +1,1 @@
+ROOT plain nav

--- a/testdata/embed-page-relative-site/section/index.html
+++ b/testdata/embed-page-relative-site/section/index.html
@@ -1,0 +1,4 @@
+<!-- title: Section -->
+<embed src="nav-markdown.md" type="text/markdown">
+<embed src="nav-plain.txt" type="text/plain">
+<embed src="nav-html.html" type="text/html">

--- a/testdata/embed-page-relative-site/section/nav-html.html
+++ b/testdata/embed-page-relative-site/section/nav-html.html
@@ -1,0 +1,1 @@
+<p>SECTION html nav</p>

--- a/testdata/embed-page-relative-site/section/nav-markdown.md
+++ b/testdata/embed-page-relative-site/section/nav-markdown.md
@@ -1,0 +1,1 @@
+<p>SECTION markdown nav</p>

--- a/testdata/embed-page-relative-site/section/nav-plain.txt
+++ b/testdata/embed-page-relative-site/section/nav-plain.txt
@@ -1,0 +1,1 @@
+SECTION plain nav

--- a/testdata/layout-embed-site/section/index.html
+++ b/testdata/layout-embed-site/section/index.html
@@ -1,0 +1,2 @@
+<!-- title: Section -->
+<p>section content</p>


### PR DESCRIPTION
## Summary

- `<embed src="...">` written in a page's own body content now resolves relative to that page's own source directory instead of always the site root — the same way a relative `<img src>`/`<a href>` resolves once a page is deployed and viewed in a browser. A subdirectory page embedding a same-named file that also exists at the site root no longer silently reads the wrong (root) copy.
- A chain of embeds (a file embedded by a page that itself embeds a further file) now has each `src` resolve against the file that wrote it, not the outermost page.
- An `<embed>` written directly into `layout.html` itself is a deliberate exception and keeps resolving against the site root, regardless of which page is being rendered — `layout.html` is a single, fixed file shared by every page, not content that lives in a particular directory, and the README's own site-wide-footer example only works if that stays true.
- External `mzs*` MIME-type plugins are unaffected — they still receive `src` exactly as written, with no resolution applied.
- The existing path-containment check (rejecting an absolute `src` or a `../` that escapes the site root) is unchanged and composes correctly with the new page-relative base.
- README's embed documentation and the audit note at `docs/audit/F7-embed-src-cwd-relative.md` (untracked, not part of this diff) are updated to describe the new behavior.

## Breaking change

Any existing site with a page in a subdirectory whose `<embed src="...">` relied on the old root-relative resolution (the `src` was written as a path from the site root rather than from that page's own directory) needs that `src` updated to be relative to the page's own directory instead. Expected to be rare in practice.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race -count=1 ./...` (all pass, including all pre-existing embed tests unmodified)
- [x] New regression tests: same-named-file-at-root-vs-subdirectory resolution, a two-level embed chain, the layout-embed-stays-root-relative exception, and containment composing correctly with the new page-relative base (both a rejected escape and an allowed one-level-up-still-inside-root case)
- [x] Live repro with a built binary: a `section/index.html` page embedding a `nav.md` present with different content at both the site root and in `section/` — confirmed the pre-fix binary picks the wrong (root) file and the fixed binary picks the correct (section-local) one